### PR TITLE
Add new WatchPidFieldsEx method

### DIFF
--- a/pkg/dcgm/api.go
+++ b/pkg/dcgm/api.go
@@ -79,7 +79,7 @@ func GetDeviceTopology(gpuId uint) ([]P2PLink, error) {
 // WatchPidFields lets DCGM start recording stats for GPU process
 // It needs to be called before calling GetProcessInfo
 func WatchPidFields() (GroupHandle, error) {
-	return watchPidFields()
+	return watchPidFields(defaultUpdateFreq, defaultMaxKeepAge, defaultMaxKeepSamples)
 }
 
 // GetProcessInfo provides detailed per GPU stats for this process


### PR DESCRIPTION
This modifies the private `watchPidFields()` method to pass through the timing/sample limit parameters to the underlying C function rather than simply use the defaults. I then added a new `WatchPidFieldsEx()` method to allow using this feature in code leveraging this library. The existing `WatchPidFields()` method maintains the original behavior.

I added this because I wanted the ability to get process-level stats at a higher frequency than the default 30s rate. This allows that to be adjusted by users of this library for different use-cases, while maintaining the default behavior.