### PR TITLE
Remove DestroyGroup function int the GetProcessInfo()

### DIFF
--- a/pkg/dcgm/process_info.go
+++ b/pkg/dcgm/process_info.go
@@ -191,7 +191,6 @@ func getProcessInfo(groupId GroupHandle, pid uint) (processInfo []ProcessInfo, e
 		}
 		processInfo = append(processInfo, pInfo)
 	}
-	_ = DestroyGroup(groupId)
 	return
 }
 


### PR DESCRIPTION
Remove the DestroyGroup() function call in the GetProcessInfo() function to avoid the problem of frequent calls to the GetProcessInfo() function stuck in DestroyGroup().

issues: #24 