### PR TITLE
Fix getSupportedMetricGroups to match actual DCGM API

### DIFF
--- a/pkg/dcgm/api.go
+++ b/pkg/dcgm/api.go
@@ -107,8 +107,8 @@ func Introspect() (DcgmStatus, error) {
 }
 
 // Get all of the profiling metric groups for a given GPU group.
-func GetSupportedMetricGroups(group GroupHandle) ([]MetricGroup, error) {
-	return getSupportedMetricGroups(group)
+func GetSupportedMetricGroups(gpuId uint) ([]MetricGroup, error) {
+	return getSupportedMetricGroups(gpuId)
 }
 
 func GetNvLinkLinkStatus() ([]NvLinkStatus, error) {

--- a/pkg/dcgm/profile.go
+++ b/pkg/dcgm/profile.go
@@ -15,12 +15,12 @@ type MetricGroup struct {
 	FieldIds []uint
 }
 
-func getSupportedMetricGroups(group GroupHandle) (groups []MetricGroup, err error) {
+func getSupportedMetricGroups(gpuId uint) (groups []MetricGroup, err error) {
 
 	var groupInfo C.dcgmProfGetMetricGroups_t
 	groupInfo.version = makeVersion3(unsafe.Sizeof(groupInfo))
 
-	groupInfo.gpuId = C.uint(group.handle)
+	groupInfo.gpuId = C.uint(gpuId)
 
 	result := C.dcgmProfGetSupportedMetricGroups(handle.handle, &groupInfo)
 


### PR DESCRIPTION
The API accepts the gpuId not a group handle