### PR TITLE
Added `--export-dynamic` linker flag for go 1.21 support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/Masterminds/semver v1.5.0
-	github.com/bits-and-blooms/bitset v1.2.1 // indirect
+	github.com/bits-and-blooms/bitset v1.2.1
 	github.com/gorilla/mux v1.8.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,6 @@
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
-github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20210525204842-7fbe8db26700 h1:1FxK6qecUUD+XAcaTIrRwhl67gDoB3IAfkuWnaqwk5o=
-github.com/NVIDIA/gpu-monitoring-tools v0.0.0-20210525204842-7fbe8db26700/go.mod h1:oKPJa5eOTkWvlT4/Y4D8Nds44Fzmww5HUK+xwO+DwTA=
-github.com/NVIDIA/gpu-monitoring-tools/bindings/go/dcgm v0.0.0-20210325210537-29b4f1784f18/go.mod h1:8qXwltEzU3idjUcVpMOv3FNgxxbDeXZPGMLyc/khWiY=
 github.com/bits-and-blooms/bitset v1.2.1 h1:M+/hrU9xlMp7t4TyTDQW97d3tRPVuKFC6zBEK16QnXY=
 github.com/bits-and-blooms/bitset v1.2.1/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=

--- a/pkg/dcgm/admin.go
+++ b/pkg/dcgm/admin.go
@@ -17,8 +17,8 @@
 package dcgm
 
 /*
-#cgo linux LDFLAGS: -ldl -Wl,--unresolved-symbols=ignore-in-object-files
-#cgo darwin LDFLAGS: -ldl -Wl,-undefined,dynamic_lookup
+#cgo linux LDFLAGS: -ldl -Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files
+#cgo darwin LDFLAGS: -ldl -Wl,--export-dynamic -Wl,-undefined,dynamic_lookup
 
 #include <dlfcn.h>
 #include "dcgm_agent.h"


### PR DESCRIPTION
When built with `go1.21.x`, `go-dcgm` panics. This happens because of the changes in the `go1.21.x` behavior in the linker. A similar issue was found and fixed in the `go-nvml` https://github.com/NVIDIA/go-nvml/pull/79. 

The PR was tested in the following way:

1. Use `go1.18.x` and run `make binaries`. 
2. Execute binaries located in the `./samples` directory.

Expected behavior: no errors.

3. Switch the environment to use `go1.21.x`, run `make clean` and `make binaries`
4. Execute binaries located in the `./samples` directory.

Expected behavior: no errors. Before the change, the error was:

```
SIGSEGV: segmentation violation
PC=0x0 m=0 sigcode=1
signal arrived during cgo execution
```

