### PR TITLE
Fix darwin do not support `--export-dynamic`

### DIFF
--- a/pkg/dcgm/admin.go
+++ b/pkg/dcgm/admin.go
@@ -18,7 +18,7 @@ package dcgm
 
 /*
 #cgo linux LDFLAGS: -ldl -Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files
-#cgo darwin LDFLAGS: -ldl -Wl,--export-dynamic -Wl,-undefined,dynamic_lookup
+#cgo darwin LDFLAGS: -ldl -Wl,-undefined,dynamic_lookup
 
 #include <dlfcn.h>
 #include "dcgm_agent.h"


### PR DESCRIPTION
which will met error:

```
go/pkg/tool/darwin_amd64/link: running clang failed: exit status 1
ld: unknown option: --export-dynamic
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```