### PR TITLE
Add ability to access GroupHandle and FieldHandle

### DIFF
--- a/pkg/dcgm/fields_test.go
+++ b/pkg/dcgm/fields_test.go
@@ -1,0 +1,19 @@
+package dcgm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldHandle(t *testing.T) {
+	fh := FieldHandle{}
+	assert.Equal(t, uintptr(0), fh.GetHandle(), "value mismatch")
+
+	inputs := []uintptr{1000, 0, 1, 10, 11, 50, 100, 1939902, 9992932938239, 999999999999999999}
+
+	for _, input := range inputs {
+		fh.SetHandle(input)
+		assert.Equal(t, input, fh.GetHandle(), "values mismatch")
+	}
+}

--- a/pkg/dcgm/gpu_group.go
+++ b/pkg/dcgm/gpu_group.go
@@ -16,6 +16,14 @@ const (
 
 type GroupHandle struct{ handle C.dcgmGpuGrp_t }
 
+func (g *GroupHandle) SetHandle(val uintptr) {
+	g.handle = C.dcgmGpuGrp_t(val)
+}
+
+func (g *GroupHandle) GetHandle() uintptr {
+	return uintptr(g.handle)
+}
+
 func GroupAllGPUs() GroupHandle {
 	return GroupHandle{C.DCGM_GROUP_ALL_GPUS}
 }
@@ -67,7 +75,8 @@ func AddLinkEntityToGroup(groupId GroupHandle, index uint, parentId uint) (err e
 }
 
 func AddEntityToGroup(groupId GroupHandle, entityGroupId Field_Entity_Group, entityId uint) (err error) {
-	result := C.dcgmGroupAddEntity(handle.handle, groupId.handle, C.dcgm_field_entity_group_t(entityGroupId), C.uint(entityId))
+	result := C.dcgmGroupAddEntity(handle.handle, groupId.handle, C.dcgm_field_entity_group_t(entityGroupId),
+		C.uint(entityId))
 	if err = errorString(result); err != nil {
 		return fmt.Errorf("Error adding entity group type %v, entity %v to group: %s", entityGroupId, entityId, err)
 	}

--- a/pkg/dcgm/gpu_group_test.go
+++ b/pkg/dcgm/gpu_group_test.go
@@ -1,0 +1,19 @@
+package dcgm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroupHandle(t *testing.T) {
+	gh := GroupHandle{}
+	assert.Equal(t, uintptr(0), gh.GetHandle(), "value mismatch")
+
+	inputs := []uintptr{1000, 0, 1, 10, 11, 50, 100, 1939902, 9992932938239, 999999999999999999}
+
+	for _, input := range inputs {
+		gh.SetHandle(input)
+		assert.Equal(t, input, gh.GetHandle(), "values mismatch")
+	}
+}


### PR DESCRIPTION
Purpose:

1. Allow access to GroupHandle and FieldHandle struct's handle attribute without making it exported. 
2. Unit tests to verify above change.