### PR TITLE
feat: expose function for listening to policy violations on a specific GPU group

### DIFF
--- a/pkg/dcgm/api.go
+++ b/pkg/dcgm/api.go
@@ -104,10 +104,15 @@ func HealthCheckByGpuId(gpuId uint) (DeviceHealth, error) {
 	return healthCheckByGpuId(gpuId)
 }
 
-// ListenForPolicyViolations sets GPU usage and error policies and notifies in case of any violations
+// ListenForPolicyViolations sets GPU usage and error policies and notifies in case of any violations on all GPUs
 func ListenForPolicyViolations(ctx context.Context, typ ...policyCondition) (<-chan PolicyViolation, error) {
 	groupId := GroupAllGPUs()
-	return registerPolicy(ctx, groupId, typ...)
+	return ListenForPolicyViolationsForGroup(ctx, groupId, typ...)
+}
+
+// ListenForPolicyViolations sets GPU usage and error policies and notifies in case of any violations on GPUs within a specific group
+func ListenForPolicyViolationsForGroup(ctx context.Context, group GroupHandle, typ ...policyCondition) (<-chan PolicyViolation, error) {
+	return registerPolicy(ctx, group, typ...)
 }
 
 // Introspect returns DCGM hostengine memory and CPU usage


### PR DESCRIPTION
== Motivation ==

Enable finer grained GPU policy violation tracking

== Details ==

The current go-dcgm library exposes a way to listen to policy violations across all GPUs. While this is useful, it does not currently help with identifying exactly which GPUs are experiencing issues. Ideally, the policy violation would contain identifying GPU information, but it seems today it does not ([struct definitions](https://github.com/NVIDIA/DCGM/blob/3fb35246cb8f8b29fca6ebb34be6c0b379645ce2/dcgmlib/dcgm_structs.h#L1679)). So instead, it would be useful if users could listen to policy violations on groups created for specific GPUs. This would allow users to then know when specific GPUs were experiencing issues.

This change exposes a new function, `ListenForPolicyViolationsForGroup`, which takes a `GroupHandle` passed by the user and listens to policy violations for that group. It also modifies `ListenForPolicyViolations` to use this new function, but with specifying the group for all GPUs — so no net change in behavior.

Signed-off-by: sanjams2 <sanjams2@users.noreply.github.com>