### PR TITLE
feat(const): add DCGM_FI_DEV_THRESHOLD_SRM 346

### DIFF
--- a/pkg/dcgm/const_fields.go
+++ b/pkg/dcgm/const_fields.go
@@ -322,6 +322,8 @@ const (
 	DCGM_FI_DEV_ECC_SBE_AGG_SRM Short = 344
 	// DCGM_FI_DEV_ECC_DBE_AGG_SRM represents the aggregate number of double-bit ECC errors detected in SRM
 	DCGM_FI_DEV_ECC_DBE_AGG_SRM Short = 345
+	// DCGM_FI_DEV_THRESHOLD_SRM represents the threshold for SRM ECC errors
+	DCGM_FI_DEV_THRESHOLD_SRM Short = 346
 	// DCGM_FI_DEV_DIAG_MEMORY_RESULT is the value for ECC memory result
 	DCGM_FI_DEV_DIAG_MEMORY_RESULT Short = 350
 	// DCGM_FI_DEV_DIAG_DIAGNOSTIC_RESULT is the value for ECC diagnostic result
@@ -1330,6 +1332,7 @@ var dcgmFields = map[string]Short{
 	"DCGM_FI_DEV_ECC_DBE_VOL_SRM":                                DCGM_FI_DEV_ECC_DBE_VOL_SRM,                                // 343
 	"DCGM_FI_DEV_ECC_SBE_AGG_SRM":                                DCGM_FI_DEV_ECC_SBE_AGG_SRM,                                // 344
 	"DCGM_FI_DEV_ECC_DBE_AGG_SRM":                                DCGM_FI_DEV_ECC_DBE_AGG_SRM,                                // 345
+	"DCGM_FI_DEV_THRESHOLD_SRM":                                  DCGM_FI_DEV_THRESHOLD_SRM,                                  // 346
 	"DCGM_FI_DEV_DIAG_MEMORY_RESULT":                             DCGM_FI_DEV_DIAG_MEMORY_RESULT,                             // 350
 	"DCGM_FI_DEV_DIAG_DIAGNOSTIC_RESULT":                         DCGM_FI_DEV_DIAG_DIAGNOSTIC_RESULT,                         // 351
 	"DCGM_FI_DEV_DIAG_PCIE_RESULT":                               DCGM_FI_DEV_DIAG_PCIE_RESULT,                               // 352


### PR DESCRIPTION
the dcgm-exporter will not export this api field as a metric returning 

```
time=2025-08-13T19:51:48.158Z level=ERROR msg="could not find DCGM field; err: unknown ExporterCounter field 'DCGM_FI_DEV_THRESHOLD_SRM'"
```

when you try to export it.

this PR adds the proper field ID so that the dcgm-exporter can export it.

tested and working in my environment:

sample metrics from the dcgm-exporter:
```
# HELP DCGM_FI_DEV_THRESHOLD_SRM bool to show if gpu srm threshold exceeded
# TYPE DCGM_FI_DEV_THRESHOLD_SRM gauge
DCGM_FI_DEV_THRESHOLD_SRM{gpu="0",UUID="snip",pci_bus_id="00000000:19:00.0",device="nvidia0",modelName="NVIDIA H100 80GB HBM3",Hostname="gb975e0",DCGM_FI_DEV_SERIAL="snip",DCGM_FI_DEV_VBIOS_VERSION="96.00.A5.00.01"} 0
DCGM_FI_DEV_THRESHOLD_SRM{gpu="1",UUID="snip",pci_bus_id="00000000:2D:00.0",device="nvidia1",modelName="NVIDIA H100 80GB HBM3",Hostname="gb975e0",DCGM_FI_DEV_SERIAL="snip",DCGM_FI_DEV_VBIOS_VERSION="96.00.A5.00.01"} 0
DCGM_FI_DEV_THRESHOLD_SRM{gpu="2",UUID="snip",pci_bus_id="00000000:3F:00.0",device="nvidia2",modelName="NVIDIA H100 80GB HBM3",Hostname="gb975e0",DCGM_FI_DEV_SERIAL="snip",DCGM_FI_DEV_VBIOS_VERSION="96.00.A5.00.01"} 0
DCGM_FI_DEV_THRESHOLD_SRM{gpu="3",UUID="snip",pci_bus_id="00000000:66:00.0",device="nvidia3",modelName="NVIDIA H100 80GB HBM3",Hostname="gb975e0",DCGM_FI_DEV_SERIAL="snip",DCGM_FI_DEV_VBIOS_VERSION="96.00.A5.00.01"} 0
DCGM_FI_DEV_THRESHOLD_SRM{gpu="4",UUID="snip",pci_bus_id="00000000:BF:00.0",device="nvidia4",modelName="NVIDIA H100 80GB HBM3",Hostname="gb975e0",DCGM_FI_DEV_SERIAL="snip",DCGM_FI_DEV_VBIOS_VERSION="96.00.A5.00.01"} 0
DCGM_FI_DEV_THRESHOLD_SRM{gpu="5",UUID="snip",pci_bus_id="00000000:E4:00.0",device="nvidia5",modelName="NVIDIA H100 80GB HBM3",Hostname="gb975e0",DCGM_FI_DEV_SERIAL="snip",DCGM_FI_DEV_VBIOS_VERSION="96.00.A5.00.01"} 0
```

tested with the following configmap

```
# Format
# If line starts with a '#' it is considered a comment
# DCGM FIELD, Prometheus metric type, help message

# Clocks
DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
DCGM_FI_DEV_APP_SM_CLOCK, gauge, SM Application clocks.
DCGM_FI_DEV_APP_MEM_CLOCK, gauge, Memory Application clocks.

# Temperature
DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).
DCGM_FI_DEV_FAN_SPEED,    gauge, Fan speed for the device in percent 0-100.

# Power
DCGM_FI_DEV_POWER_USAGE,              gauge, Power draw (in W).
DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).

# PCIE
DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.

# Utilization (the sample period varies depending on the product)
DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).
DCGM_FI_DEV_DEC_UTIL,      gauge, Decoder utilization (in %).
DCGM_FI_DEV_PSTATE,        gauge, Performance state (P-State) 0-15.
DCGM_FI_DEV_VGPU_UTILIZATIONS,        gauge, Utilization values for vGPUs running on the device.

# Errors and violations
DCGM_FI_DEV_XID_ERRORS,            gauge,   Value of the last XID error encountered.
DCGM_FI_DEV_POWER_VIOLATION,       counter, Throttling duration due to power constraints (in us).
DCGM_FI_DEV_THERMAL_VIOLATION,     counter, Throttling duration due to thermal constraints (in us).
DCGM_FI_DEV_SYNC_BOOST_VIOLATION,  counter, Throttling duration due to sync-boost constraints (in us).
DCGM_FI_DEV_BOARD_LIMIT_VIOLATION, counter, Throttling duration due to board limit constraints (in us).
DCGM_FI_DEV_LOW_UTIL_VIOLATION,    counter, Throttling duration due to low utilization (in us).
DCGM_FI_DEV_RELIABILITY_VIOLATION, counter, Throttling duration due to reliability constraints (in us).
DCGM_FI_DEV_TOTAL_APP_CLOCKS_VIOLATION, counter, App clock violation limit.
DCGM_FI_DEV_TOTAL_BASE_CLOCKS_VIOLATION, counter, Base clock violation limit.
DCGM_FI_DEV_CLOCK_THROTTLE_REASONS, counter, Current clock throttle reasons.

# Memory usage
DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
DCGM_FI_DEV_FB_TOTAL, gauge, Total Frame Buffer of the GPU in MB.
DCGM_FI_DEV_FB_RESERVED, gauge, Reserved Frame Buffer in MB.
DCGM_FI_DEV_VGPU_MEMORY_USAGE, gauge, Memory usage of the vGPU instance.
DCGM_FI_DEV_THRESHOLD_SRM, gauge, bool to show if gpu srm threshold exceeded

# ECC
DCGM_FI_DEV_ECC_SBE_VOL_TOTAL, counter, Total number of single-bit volatile ECC errors.
DCGM_FI_DEV_ECC_DBE_VOL_TOTAL, counter, Total number of double-bit volatile ECC errors.
DCGM_FI_DEV_ECC_SBE_AGG_TOTAL, counter, Total number of single-bit persistent ECC errors.
DCGM_FI_DEV_ECC_DBE_AGG_TOTAL, counter, Total number of double-bit persistent ECC errors.

# Retired pages
DCGM_FI_DEV_RETIRED_SBE,     counter, Total number of retired pages due to single-bit errors.
DCGM_FI_DEV_RETIRED_DBE,     counter, Total number of retired pages due to double-bit errors.
DCGM_FI_DEV_RETIRED_PENDING, counter, Total number of pages pending retirement.

# NVLink
DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL, counter, Total number of NVLink flow-control CRC errors.
DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL, counter, Total number of NVLink data CRC errors.
DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL,   counter, Total number of NVLink retries.
DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL, counter, Total number of NVLink recovery errors.
DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL,            counter, Total number of NVLink bandwidth counters for all lanes
DCGM_FI_PROF_NVLINK_TX_BYTES,            gauge, The number of bytes of active NvLink tx (transmit) data including both header and payload.
DCGM_FI_PROF_NVLINK_RX_BYTES,            gauge, The number of bytes of active NvLink rx (read) data including both header and payload.
DCGM_FI_DEV_GPU_NVLINK_ERRORS,     gauge, GPU NVLink error information
DCGM_FI_DEV_NVSWITCH_FATAL_ERRORS,     gauge, GPU NVLink fatal error information

# VGPU License status
#DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status

# Remapped rows
DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS,   counter, Number of remapped rows for correctable errors
DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_PARTIAL, gauge, Number of partial remapped rows available.
DCGM_FI_DEV_ROW_REMAP_FAILURE,           gauge,   Whether remapping of rows has failed

# Static configuration information. These appear as labels on the other metrics
# DCGM_FI_DRIVER_VERSION,        label, Driver Version
# DCGM_FI_NVML_VERSION,          label, NVML Version
# DCGM_FI_DEV_BRAND,             label, Device Brand
DCGM_FI_DEV_SERIAL,            label, Device Serial Number
# DCGM_FI_DEV_OEM_INFOROM_VER,   label, OEM inforom version
# DCGM_FI_DEV_ECC_INFOROM_VER,   label, ECC inforom version
# DCGM_FI_DEV_POWER_INFOROM_VER, label, Power management object inforom version
# DCGM_FI_DEV_INFOROM_IMAGE_VER, label, Inforom image version
DCGM_FI_DEV_VBIOS_VERSION,     label, VBIOS version of the device

# DCP metrics,,
DCGM_FI_PROF_GR_ENGINE_ACTIVE,   gauge, Ratio of time the graphics engine is active (in %).
DCGM_FI_PROF_SM_ACTIVE,          gauge, The ratio of cycles an SM has at least 1 warp assigned (in %).
DCGM_FI_PROF_SM_OCCUPANCY,       gauge, The ratio of number of warps resident on an SM (in %).
DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active (in %).
DCGM_FI_PROF_DRAM_ACTIVE,        gauge, Ratio of cycles the device memory interface is active sending or receiving data (in %).
DCGM_FI_PROF_PIPE_FP64_ACTIVE,   gauge, Ratio of cycles the fp64 pipes are active (in %).
DCGM_FI_PROF_PIPE_FP32_ACTIVE,   gauge, Ratio of cycles the fp32 pipes are active (in %).
DCGM_FI_PROF_PIPE_FP16_ACTIVE,   gauge, Ratio of cycles the fp16 pipes are active (in %).
DCGM_FI_PROF_PCIE_TX_BYTES,      counter, The number of bytes of active pcie tx data including both header and payload.
DCGM_FI_PROF_PCIE_RX_BYTES,      counter, The number of bytes of active pcie rx data including both header and payload.
```