### PR TITLE
use C.int64_t and C.uint64_t instead of C.long and C.ulong

### DIFF
--- a/pkg/dcgm/internal.go
+++ b/pkg/dcgm/internal.go
@@ -100,7 +100,7 @@ func InjectFieldValue(gpu uint, fieldID Short, fieldType uint, status int, ts in
 		fieldId:   C.ushort(fieldID),
 		fieldType: C.ushort(fieldType),
 		status:    C.int(status),
-		ts:        C.long(ts),
+		ts:        C.int64_t(ts),
 	}
 
 	switch fieldType {

--- a/pkg/dcgm/policy.go
+++ b/pkg/dcgm/policy.go
@@ -366,7 +366,7 @@ func registerPolicy(ctx context.Context, groupID GroupHandle, typ ...policyCondi
 		return nil, err
 	}
 
-	result := C.dcgmPolicyRegister_v2(handle.handle, groupID.handle, condition, C.fpRecvUpdates(C.violationNotify), C.ulong(0))
+	result := C.dcgmPolicyRegister_v2(handle.handle, groupID.handle, condition, C.fpRecvUpdates(C.violationNotify), C.uint64_t(0))
 
 	if err = errorString(result); err != nil {
 		return nil, &Error{msg: C.GoString(C.errorString(result)), Code: result}


### PR DESCRIPTION
I tried to build tests for a go project with a go-dcgm dependency on a macbook, and it failed to compile with errors like:

cannot use _Ctype_long(ts) (value of int64 type _Ctype_long) as _Ctype_int64_t value in struct literal

This patch fixes the errors by making the width explicitly defined, which better matches the header file definitions.