### PR TITLE
gen-fields: resolve deprecated #define aliases into legacyDCGMFields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ install-pre-commit:
 generate:
 	@echo "Generating Go code from headers..."
 	go generate ./...
+	gofmt -w pkg/dcgm/const_fields.go
 
 check-generate: generate
 	@echo "Checking if generated code is up to date..."

--- a/cmd/gen-fields/README.md
+++ b/cmd/gen-fields/README.md
@@ -4,12 +4,19 @@ This tool generates Go constants from the DCGM C header file `dcgm_fields.h`.
 
 ## Overview
 
-The generator parses `dcgm_fields.h` and extracts all DCGM field definitions (`DCGM_FI_*` constants), then generates a Go file with:
+The generator parses `dcgm_fields.h` and generates a Go file with:
 
-- Typed constants for each DCGM field
-- Field name mappings for lookup by string name
-- Helper functions (`GetFieldID`, `GetFieldIDOrPanic`, etc.)
-- Legacy field mappings for backward compatibility
+- Typed constants for each `#define DCGM_FI_X <int>` in the header.
+- `dcgmFields`: maps canonical name to field ID.
+- `legacyDCGMFields`: maps backward-compatible names to the same IDs.
+  Populated from two sources:
+    - Hand-curated DCGM 1.x era lowercase names (e.g. `dcgm_gpu_temp`),
+      preserved across regenerations.
+    - Deprecated-alias `#define OLD NEW` lines in the header, either
+      inside an `#ifdef DCGM_DEPRECATED` block or preceded by a
+      `Deprecated:` comment.
+- Helper functions: `GetFieldID`, `GetFieldIDOrPanic`, `IsLegacyField`,
+  `IsCurrentField`.
 
 ## Usage
 
@@ -39,15 +46,21 @@ Arguments:
 
 ## How It Works
 
-1. **Parse Header File**: Reads `dcgm_fields.h` and extracts all `#define DCGM_FI_*` definitions
-2. **Extract Field Information**:
-   - Field name (e.g., `DCGM_FI_DEV_GPU_TEMP`)
-   - Field ID (numeric value)
-   - Field comment/description
-3. **Generate Go Code**: Uses Go templates to create:
-   - Constant definitions: `DCGM_FI_DEV_GPU_TEMP Short = 150`
-   - Field name maps for string-based lookup
-   - Helper functions for field ID resolution
+1. **Parse header**: reads `dcgm_fields.h`. Two shapes of `#define` are extracted:
+   - `#define DCGM_FI_X <int>` -> canonical field, with preceding comment
+     captured as its description.
+   - `#define DCGM_FI_OLD DCGM_FI_NEW` -> deprecated alias. Recorded only
+     when the alias is inside an `#ifdef DCGM_DEPRECATED` block OR its
+     preceding comment contains `Deprecated:`. Other alias-style
+     `#define`s (e.g. range sentinels) are silently skipped.
+2. **Resolve aliases**: each recorded alias is mapped to its target
+   field's canonical ID. If a target isn't a known field, generation
+   fails so header churn can't silently drop previously-exposed names.
+3. **Preserve curated legacy names**: lowercase DCGM 1.x names in the
+   previously-generated `const_fields.go` are round-tripped. `DCGM_FI_*`
+   entries are not preserved here; they re-derive from step 2 every run.
+4. **Emit Go code** via `template.go`, then run `gofmt -w` on the output
+   so `make check-generate` stays stable.
 
 ## Output
 
@@ -55,19 +68,31 @@ The generated `const_fields.go` file contains:
 
 ```go
 const (
-    DCGM_FI_DEV_GPU_TEMP Short = 150
+    DCGM_FI_DEV_GPU_TEMP    Short = 150
     DCGM_FI_DEV_POWER_USAGE Short = 155
     // ... etc
 )
 
 var dcgmFields = map[string]Short{
-    "dcgm_gpu_temp": 150,
+    "DCGM_FI_DEV_GPU_TEMP":    150,
+    "DCGM_FI_DEV_POWER_USAGE": 155,
+    // ... etc
+}
+
+var legacyDCGMFields = map[string]Short{
+    // DCGM 1.x lowercase names, preserved from the prior generation:
+    "dcgm_gpu_temp":   150,
     "dcgm_power_usage": 155,
+    // Deprecated aliases resolved from dcgm_fields.h:
+    "DCGM_FI_DEV_CLOCK_THROTTLE_REASONS":  112,
+    "DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL": 449,
     // ... etc
 }
 
 func GetFieldID(fieldName string) (Short, bool) { ... }
 func GetFieldIDOrPanic(fieldName string) Short { ... }
+func IsLegacyField(fieldName string) bool     { ... }
+func IsCurrentField(fieldName string) bool    { ... }
 ```
 
 ## Template

--- a/cmd/gen-fields/main.go
+++ b/cmd/gen-fields/main.go
@@ -48,17 +48,37 @@ func main() {
 	outputPath := os.Args[2]
 
 	// Parse header file
-	fields, err := parseHeader(headerPath)
+	fields, aliases, err := parseHeader(headerPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error parsing header: %v\n", err)
 		os.Exit(1)
 	}
 
-	// Extract legacy fields from existing file
+	// Resolve deprecated aliases to their target field IDs.
+	aliasLegacy, err := resolveAliases(fields, aliases)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving aliases: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Extract legacy fields from existing file. Missing file on first-run is
+	// fine; anything else (unreadable file, unrecognised legacy entry) is
+	// treated as a hard error so we don't silently regenerate with lost
+	// backward-compat names.
 	legacyFields, err := extractLegacyFields(outputPath)
 	if err != nil {
-		// If file doesn't exist yet, start with empty legacy map
-		legacyFields = make(map[string]int)
+		if os.IsNotExist(err) {
+			legacyFields = make(map[string]int)
+		} else {
+			fmt.Fprintf(os.Stderr, "Error extracting legacy fields: %v\n", err)
+			os.Exit(1)
+		}
+	}
+
+	// Merge resolved aliases into the legacy map. Alias names start with
+	// DCGM_FI_ and so never collide with the lowercase curated 1.x names.
+	for name, id := range aliasLegacy {
+		legacyFields[name] = id
 	}
 
 	// Generate output
@@ -73,48 +93,144 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Generated %d fields to %s\n", len(fields), outputPath)
+	fmt.Printf("Generated %d fields (+ %d deprecated aliases) to %s\n",
+		len(fields), len(aliasLegacy), outputPath)
 }
 
-func parseHeader(path string) ([]Field, error) {
+// containsDeprecatedMarker reports whether the line contains the
+// case-insensitive substring "deprecated:" -- the exact marker used in
+// dcgm_fields.h to annotate deprecated aliases. Matching a loose "deprecated"
+// substring would false-positive on adjectival mentions.
+func containsDeprecatedMarker(line string) bool {
+	return strings.Contains(strings.ToLower(line), "deprecated:")
+}
+
+func parseHeader(path string) ([]Field, map[string]string, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open header file: %w", err)
+		return nil, nil, fmt.Errorf("failed to open header file: %w", err)
 	}
 	defer file.Close()
 
-	// Pattern: #define DCGM_FI_XXX 123
+	// #define DCGM_FI_XXX 123
 	definePattern := regexp.MustCompile(`^#define\s+(DCGM_FI_\w+)\s+(\d+)`)
+	// #define DCGM_FI_OLD DCGM_FI_NEW -- deprecated-alias shape.
+	aliasPattern := regexp.MustCompile(`^#define\s+(DCGM_FI_\w+)\s+(DCGM_FI_\w+)\s*$`)
+	// Content of a block-comment interior line: " * <content>".
 	commentPattern := regexp.MustCompile(`^\s*\*\s*(.+)$`)
 
 	var fields []Field
+	aliases := make(map[string]string)
+
 	var lastComment string
+	// inCommentBlock tracks /** ... */ spans so the closing */ never feeds
+	// commentPattern (which would otherwise capture "/" and corrupt
+	// lastComment -- the origin of the "// X represents /" artefacts in the
+	// previously-generated output).
+	var inCommentBlock bool
+	// commentHasDeprecated is set to true when any line inside the current
+	// comment block contains case-insensitive "deprecated:". Consumed by the
+	// alias handler to include outside-#ifdef-block cases like
+	// DCGM_FI_DEV_CLOCK_THROTTLE_REASONS.
+	var commentHasDeprecated bool
+	// inDeprecatedBlock tracks the #ifdef DCGM_DEPRECATED ... #endif span.
+	// A small nesting counter handles any nested #ifdef/#ifndef/#if inside.
+	var inDeprecatedBlock bool
+	var deprecatedBlockDepth int
 
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
 
-		// Check for comments that describe the next field
-		if strings.Contains(line, "/*") || strings.Contains(line, "*") {
+		// Blank line preserves comment state.
+		if trimmed == "" {
+			continue
+		}
+
+		// Deprecated-block entry/exit. Track nesting so any #ifdef/#ifndef/#if
+		// inside the block doesn't prematurely close it on its #endif.
+		if trimmed == "#ifdef DCGM_DEPRECATED" {
+			inDeprecatedBlock = true
+			deprecatedBlockDepth = 1
+			lastComment = ""
+			commentHasDeprecated = false
+			continue
+		}
+		if inDeprecatedBlock {
+			if strings.HasPrefix(trimmed, "#ifdef ") ||
+				strings.HasPrefix(trimmed, "#ifndef ") ||
+				strings.HasPrefix(trimmed, "#if ") {
+				deprecatedBlockDepth++
+				lastComment = ""
+				commentHasDeprecated = false
+				continue
+			}
+			if strings.HasPrefix(trimmed, "#endif") {
+				deprecatedBlockDepth--
+				if deprecatedBlockDepth == 0 {
+					inDeprecatedBlock = false
+				}
+				lastComment = ""
+				commentHasDeprecated = false
+				continue
+			}
+		}
+
+		hasOpen := strings.Contains(line, "/*")
+		hasClose := strings.Contains(line, "*/")
+
+		// Single-line block like "/** @} */" or "/** Deprecated: X */":
+		// inspect for the deprecated marker, do not enter block mode, do not
+		// capture as field-describing content.
+		if hasOpen && hasClose {
+			if containsDeprecatedMarker(line) {
+				commentHasDeprecated = true
+			}
+			inCommentBlock = false
+			continue
+		}
+
+		// Block opener without a matching close on the same line.
+		if hasOpen {
+			inCommentBlock = true
+			lastComment = ""
+			commentHasDeprecated = false
+			continue
+		}
+
+		// Block closer. Explicitly does NOT update lastComment; "*/" trimmed
+		// would match commentPattern as " * /" and capture "/".
+		if hasClose && inCommentBlock {
+			inCommentBlock = false
+			continue
+		}
+
+		// Interior of a block comment.
+		if inCommentBlock {
 			if matches := commentPattern.FindStringSubmatch(line); len(matches) > 1 {
 				lastComment = strings.TrimSpace(matches[1])
+			}
+			if containsDeprecatedMarker(line) {
+				commentHasDeprecated = true
 			}
 			continue
 		}
 
-		// Check for #define DCGM_FI_*
+		// Integer #define DCGM_FI_*.
 		if matches := definePattern.FindStringSubmatch(line); len(matches) == 3 {
 			name := matches[1]
 			idStr := matches[2]
 
 			id, err := strconv.Atoi(idStr)
 			if err != nil {
+				lastComment = ""
+				commentHasDeprecated = false
 				continue
 			}
 
 			comment := lastComment
 			if comment != "" {
-				// Clean up comment
 				comment = strings.TrimSpace(comment)
 				if !strings.HasPrefix(comment, "represents") {
 					comment = "represents " + comment
@@ -128,21 +244,78 @@ func parseHeader(path string) ([]Field, error) {
 			})
 
 			lastComment = ""
+			commentHasDeprecated = false
+			continue
 		}
+
+		// Alias #define DCGM_FI_OLD DCGM_FI_NEW. Accept only if deprecated
+		// either by position (inside #ifdef DCGM_DEPRECATED) or by an explicit
+		// "Deprecated:" comment. Everything else is silently dropped -- the
+		// common case is range sentinels like DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST
+		// and it is not useful to log one per run.
+		if matches := aliasPattern.FindStringSubmatch(line); len(matches) == 3 {
+			aliasName := matches[1]
+			targetName := matches[2]
+			if inDeprecatedBlock || commentHasDeprecated {
+				aliases[aliasName] = targetName
+			}
+			lastComment = ""
+			commentHasDeprecated = false
+			continue
+		}
+
+		// Any other non-blank line resets comment state so a comment meant for
+		// one field never leaks onto a later construct.
+		lastComment = ""
+		commentHasDeprecated = false
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error reading header file: %w", err)
+		return nil, nil, fmt.Errorf("error reading header file: %w", err)
 	}
 
-	// Sort by ID
+	// Sort by ID for deterministic output.
 	sort.Slice(fields, func(i, j int) bool {
 		return fields[i].ID < fields[j].ID
 	})
 
-	return fields, nil
+	return fields, aliases, nil
 }
 
+// resolveAliases maps each deprecated alias to its target field's ID.
+// Returns an error if any alias target is not a known field: we would rather
+// fail generation loudly than silently ship a legacy map missing names that
+// were previously exposed.
+func resolveAliases(fields []Field, aliases map[string]string) (map[string]int, error) {
+	fieldByName := make(map[string]int, len(fields))
+	for _, f := range fields {
+		fieldByName[f.Name] = f.ID
+	}
+
+	resolved := make(map[string]int, len(aliases))
+	for alias, target := range aliases {
+		id, ok := fieldByName[target]
+		if !ok {
+			return nil, fmt.Errorf(
+				"deprecated alias %q points at unknown target %q; check dcgm_fields.h",
+				alias, target)
+		}
+		resolved[alias] = id
+	}
+	return resolved, nil
+}
+
+// extractLegacyFields preserves curated legacy entries across regeneration.
+// Provenance rules:
+//
+//   - Lowercase names (the hand-maintained DCGM 1.x backward-compat family,
+//     e.g. "dcgm_gpu_temp") are preserved.
+//   - DCGM_FI_* uppercase names are re-derived every run by resolveAliases
+//     (see main), so they are skipped here to avoid stale entries persisting
+//     after they disappear from the header.
+//   - Any other uppercase name is an unrecognised provenance and fails
+//     generation loudly, so hand-added names can't silently disappear on the
+//     next regenerate and so unexpected patterns surface immediately.
 func extractLegacyFields(path string) (map[string]int, error) {
 	file, err := os.Open(path)
 	if err != nil {
@@ -178,8 +351,25 @@ func extractLegacyFields(path string) (map[string]int, error) {
 			if matches := entryPattern.FindStringSubmatch(line); len(matches) == 3 {
 				name := matches[1]
 				id, err := strconv.Atoi(matches[2])
-				if err == nil {
+				if err != nil {
+					continue
+				}
+
+				switch {
+				case name == strings.ToLower(name):
+					// Curated DCGM 1.x backward-compat name.
 					legacyFields[name] = id
+				case strings.HasPrefix(name, "DCGM_FI_"):
+					// Generated alias; skip so it can be re-derived by
+					// resolveAliases. Stale entries removed from the header
+					// disappear naturally on regeneration.
+					continue
+				default:
+					return nil, fmt.Errorf(
+						"extractLegacyFields: %q has unrecognised provenance "+
+							"(neither a lowercase DCGM 1.x name nor a DCGM_FI_* alias); "+
+							"teach the generator how to regenerate it before adding it",
+						name)
 				}
 			}
 		}

--- a/cmd/gen-fields/main_test.go
+++ b/cmd/gen-fields/main_test.go
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeHeader(t *testing.T, contents string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dcgm_fields.h")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("writing test header: %v", err)
+	}
+	return path
+}
+
+func findField(fields []Field, name string) (Field, bool) {
+	for _, f := range fields {
+		if f.Name == name {
+			return f, true
+		}
+	}
+	return Field{}, false
+}
+
+// Plain integer defines are picked up and the aliases map is empty.
+func TestParseHeader_IntegerDefines(t *testing.T) {
+	path := writeHeader(t, `
+/**
+ * Field Foo.
+ */
+#define DCGM_FI_DEV_FOO 1
+
+/**
+ * Field Bar.
+ */
+#define DCGM_FI_DEV_BAR 2
+`)
+
+	fields, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+
+	if len(fields) != 2 {
+		t.Fatalf("want 2 fields, got %d: %+v", len(fields), fields)
+	}
+	if len(aliases) != 0 {
+		t.Fatalf("want no aliases, got %v", aliases)
+	}
+}
+
+// Alias inside #ifdef DCGM_DEPRECATED is recorded.
+func TestParseHeader_AliasInsideDeprecatedBlock_Accepted(t *testing.T) {
+	path := writeHeader(t, `
+/**
+ * Throughput.
+ */
+#define DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL 449
+
+#define DCGM_DEPRECATED
+
+#ifdef DCGM_DEPRECATED
+#define DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL    DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL
+#endif
+`)
+
+	_, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+
+	target, ok := aliases["DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"]
+	if !ok {
+		t.Fatalf("expected BANDWIDTH_TOTAL alias to be recorded, got %v", aliases)
+	}
+	if target != "DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL" {
+		t.Errorf("wrong alias target: %q", target)
+	}
+}
+
+// Alias outside the #ifdef block is accepted when its preceding comment
+// block contains "Deprecated:".
+func TestParseHeader_AliasOutsideBlockWithDeprecatedComment_Accepted(t *testing.T) {
+	path := writeHeader(t, `
+/**
+ * Clock events.
+ */
+#define DCGM_FI_DEV_CLOCKS_EVENT_REASONS 112
+
+/**
+ * Deprecated: Use DCGM_FI_DEV_CLOCKS_EVENT_REASONS instead
+ */
+#define DCGM_FI_DEV_CLOCK_THROTTLE_REASONS DCGM_FI_DEV_CLOCKS_EVENT_REASONS
+`)
+
+	_, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+
+	target, ok := aliases["DCGM_FI_DEV_CLOCK_THROTTLE_REASONS"]
+	if !ok {
+		t.Fatalf("expected CLOCK_THROTTLE_REASONS alias to be recorded, got %v", aliases)
+	}
+	if target != "DCGM_FI_DEV_CLOCKS_EVENT_REASONS" {
+		t.Errorf("wrong alias target: %q", target)
+	}
+}
+
+// Alias outside the block with a non-deprecating comment (range sentinels,
+// e.g. DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST) is silently rejected.
+func TestParseHeader_AliasOutsideBlockWithoutDeprecation_Rejected(t *testing.T) {
+	path := writeHeader(t, `
+/**
+ * Lane zero bytes.
+ */
+#define DCGM_FI_PROF_NVLINK_L0_TX_BYTES 1000
+
+/**
+ * NVLink throughput First.
+ */
+#define DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST DCGM_FI_PROF_NVLINK_L0_TX_BYTES
+`)
+
+	_, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+
+	if _, ok := aliases["DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST"]; ok {
+		t.Errorf("range sentinel was accepted as a deprecated alias: %v", aliases)
+	}
+	if len(aliases) != 0 {
+		t.Errorf("expected no aliases, got %v", aliases)
+	}
+}
+
+// The closing "*/" line must not be captured as comment content; the
+// preceding comment should reach the #define intact. Pins the fix for the
+// pre-existing "X represents /" rendering bug.
+func TestParseHeader_ClosingStarSlashDoesNotPolluteComment(t *testing.T) {
+	path := writeHeader(t, `
+/**
+ * Memory Application clocks
+ */
+#define DCGM_FI_DEV_APP_MEM_CLOCK 111
+`)
+
+	fields, _, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+
+	f, ok := findField(fields, "DCGM_FI_DEV_APP_MEM_CLOCK")
+	if !ok {
+		t.Fatalf("field not parsed")
+	}
+	if f.Comment == "represents /" || strings.HasSuffix(f.Comment, "/") {
+		t.Errorf("comment corrupted by */ line: %q", f.Comment)
+	}
+	if !strings.Contains(f.Comment, "Memory Application clocks") {
+		t.Errorf("lost real comment content: %q", f.Comment)
+	}
+}
+
+// A single-line "/** @} */" marker must not leave the parser stuck in
+// comment-block mode. A following alias is handled normally.
+func TestParseHeader_SingleLineBlockDoesNotGetStuck(t *testing.T) {
+	path := writeHeader(t, `
+/**
+ * Lane zero.
+ */
+#define DCGM_FI_PROF_NVLINK_L0_TX_BYTES 1000
+
+/** @} */
+
+/**
+ * NVLink throughput First.
+ */
+#define DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST DCGM_FI_PROF_NVLINK_L0_TX_BYTES
+`)
+
+	fields, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+
+	// If the parser were stuck in comment-block mode, the L0_TX_BYTES field
+	// would never be recorded because the "#define" handler wouldn't run.
+	if _, ok := findField(fields, "DCGM_FI_PROF_NVLINK_L0_TX_BYTES"); !ok {
+		t.Errorf("field after single-line block was lost: %+v", fields)
+	}
+	// And the non-deprecated alias after the marker should still be rejected.
+	if _, ok := aliases["DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST"]; ok {
+		t.Errorf("single-line marker caused false-positive on later alias: %v", aliases)
+	}
+}
+
+// A "Deprecated:" comment attached to a numeric #define must not leak onto a
+// later alias. The header shape under test mirrors DCGM_FI_DEV_PCIE_TX_THROUGHPUT.
+func TestParseHeader_DeprecatedCommentOnNumericDefineDoesNotLeakToAlias(t *testing.T) {
+	path := writeHeader(t, `
+/**
+ * Canonical target.
+ */
+#define DCGM_FI_PROF_PCIE_TX_BYTES 1010
+
+/**
+ * PCIe Tx utilization information
+ *
+ * Deprecated: Use DCGM_FI_PROF_PCIE_TX_BYTES instead.
+ */
+#define DCGM_FI_DEV_PCIE_TX_THROUGHPUT 200
+
+/**
+ * Lane zero.
+ */
+#define DCGM_FI_PROF_NVLINK_L0_TX_BYTES 1000
+
+/**
+ * NVLink throughput First.
+ */
+#define DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST DCGM_FI_PROF_NVLINK_L0_TX_BYTES
+`)
+
+	_, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+
+	// The later alias must NOT be picked up as deprecated just because an
+	// earlier numeric #define had a "Deprecated:" comment.
+	if _, ok := aliases["DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST"]; ok {
+		t.Errorf("deprecated state leaked from an earlier numeric define onto a later alias: %v", aliases)
+	}
+}
+
+// resolveAliases returns an error when the target of a deprecated alias
+// isn't in the fields slice.
+func TestResolveAliases_TargetMissing(t *testing.T) {
+	fields := []Field{{Name: "DCGM_FI_DEV_REAL", ID: 1}}
+	aliases := map[string]string{"DCGM_FI_DEV_OLD": "DCGM_FI_DEV_GONE"}
+
+	_, err := resolveAliases(fields, aliases)
+	if err == nil {
+		t.Fatalf("expected error when alias target is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "DCGM_FI_DEV_GONE") {
+		t.Errorf("error should name the missing target, got %q", err)
+	}
+}
+
+// Lowercase curated legacy entries in the existing output file are
+// preserved across regeneration.
+func TestGenerateOutput_PreservesCuratedLowercaseLegacy(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "const_fields.go")
+
+	// Seed an existing output containing a curated lowercase entry.
+	seeded := `package dcgm
+
+const (
+)
+var dcgmFields = map[string]Short{
+}
+var legacyDCGMFields = map[string]Short{
+	"dcgm_gpu_temp": 150,
+}
+`
+	if err := os.WriteFile(outputPath, []byte(seeded), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	legacyFields, err := extractLegacyFields(outputPath)
+	if err != nil {
+		t.Fatalf("extractLegacyFields: %v", err)
+	}
+
+	if got := legacyFields["dcgm_gpu_temp"]; got != 150 {
+		t.Errorf("lost curated lowercase entry; got %v", legacyFields)
+	}
+}
+
+// DCGM_FI_* uppercase entries in the existing output file are NOT
+// preserved. They re-derive from the header via resolveAliases, so stale
+// entries (aliases removed from the header) disappear naturally.
+func TestGenerateOutput_StaleGeneratedAliasNotPreserved(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "const_fields.go")
+
+	seeded := `package dcgm
+
+const (
+)
+var dcgmFields = map[string]Short{
+}
+var legacyDCGMFields = map[string]Short{
+	"dcgm_gpu_temp": 150,
+	"DCGM_FI_DEV_SOMETHING_REMOVED": 99,
+}
+`
+	if err := os.WriteFile(outputPath, []byte(seeded), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	legacyFields, err := extractLegacyFields(outputPath)
+	if err != nil {
+		t.Fatalf("extractLegacyFields: %v", err)
+	}
+
+	if _, ok := legacyFields["DCGM_FI_DEV_SOMETHING_REMOVED"]; ok {
+		t.Errorf("stale DCGM_FI_* entry was preserved; got %v", legacyFields)
+	}
+	if got := legacyFields["dcgm_gpu_temp"]; got != 150 {
+		t.Errorf("curated lowercase entry lost alongside stale drop; got %v", legacyFields)
+	}
+}
+
+// An uppercase non-DCGM_FI_* entry in the existing output is unrecognised
+// provenance and causes a hard error.
+func TestExtractLegacyFields_UnrecognisedUppercaseErrors(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "const_fields.go")
+
+	seeded := `package dcgm
+var legacyDCGMFields = map[string]Short{
+	"MYSTERY_UPPERCASE_NAME": 777,
+}
+`
+	if err := os.WriteFile(outputPath, []byte(seeded), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	_, err := extractLegacyFields(outputPath)
+	if err == nil {
+		t.Fatalf("expected error on unrecognised uppercase entry, got nil")
+	}
+	if !strings.Contains(err.Error(), "MYSTERY_UPPERCASE_NAME") {
+		t.Errorf("error should name the offending entry, got %q", err)
+	}
+}

--- a/cmd/gen-fields/main_test.go
+++ b/cmd/gen-fields/main_test.go
@@ -184,20 +184,28 @@ func TestParseHeader_ClosingStarSlashDoesNotPolluteComment(t *testing.T) {
 }
 
 // A single-line "/** @} */" marker must not leave the parser stuck in
-// comment-block mode. A following alias is handled normally.
+// comment-block mode. Every assertion in this test describes something
+// that happens strictly AFTER the marker -- if the parser got stuck,
+// these assertions fail.
 func TestParseHeader_SingleLineBlockDoesNotGetStuck(t *testing.T) {
 	path := writeHeader(t, `
-/**
- * Lane zero.
- */
-#define DCGM_FI_PROF_NVLINK_L0_TX_BYTES 1000
-
 /** @} */
 
 /**
- * NVLink throughput First.
+ * Field described after the marker.
  */
-#define DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST DCGM_FI_PROF_NVLINK_L0_TX_BYTES
+#define DCGM_FI_DEV_AFTER_MARKER 999
+
+#define DCGM_DEPRECATED
+
+#ifdef DCGM_DEPRECATED
+#define DCGM_FI_DEV_POST_MARKER_ALIAS DCGM_FI_DEV_AFTER_MARKER
+#endif
+
+/**
+ * Range sentinel with a non-deprecating comment, after the marker.
+ */
+#define DCGM_FI_PROF_POST_MARKER_SENTINEL DCGM_FI_DEV_AFTER_MARKER
 `)
 
 	fields, aliases, err := parseHeader(path)
@@ -205,14 +213,30 @@ func TestParseHeader_SingleLineBlockDoesNotGetStuck(t *testing.T) {
 		t.Fatalf("parseHeader: %v", err)
 	}
 
-	// If the parser were stuck in comment-block mode, the L0_TX_BYTES field
-	// would never be recorded because the "#define" handler wouldn't run.
-	if _, ok := findField(fields, "DCGM_FI_PROF_NVLINK_L0_TX_BYTES"); !ok {
-		t.Errorf("field after single-line block was lost: %+v", fields)
+	// (1) If the parser were stuck in comment-block mode, the integer
+	// define after the marker would never run the #define handler and
+	// no field would be recorded.
+	f, ok := findField(fields, "DCGM_FI_DEV_AFTER_MARKER")
+	if !ok {
+		t.Fatalf("parser stuck after /** @} */: field AFTER_MARKER was never recorded; got %+v", fields)
 	}
-	// And the non-deprecated alias after the marker should still be rejected.
-	if _, ok := aliases["DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST"]; ok {
-		t.Errorf("single-line marker caused false-positive on later alias: %v", aliases)
+
+	// (2) The marker line itself must not be captured as comment content
+	// for the following field.
+	if !strings.Contains(f.Comment, "Field described after the marker") {
+		t.Errorf("comment on field AFTER_MARKER is not the expected one (marker line may have polluted state): %q", f.Comment)
+	}
+
+	// (3) The #ifdef DCGM_DEPRECATED block after the marker must still
+	// be enterable -- the deprecated alias inside should be recorded.
+	if _, ok := aliases["DCGM_FI_DEV_POST_MARKER_ALIAS"]; !ok {
+		t.Errorf("deprecated alias defined after the marker was not recorded: %v", aliases)
+	}
+
+	// (4) And a non-deprecated alias after the marker should still be
+	// silently rejected by the scope filter.
+	if _, ok := aliases["DCGM_FI_PROF_POST_MARKER_SENTINEL"]; ok {
+		t.Errorf("range sentinel after the marker was accepted as deprecated: %v", aliases)
 	}
 }
 
@@ -272,7 +296,7 @@ func TestResolveAliases_TargetMissing(t *testing.T) {
 
 // Lowercase curated legacy entries in the existing output file are
 // preserved across regeneration.
-func TestGenerateOutput_PreservesCuratedLowercaseLegacy(t *testing.T) {
+func TestExtractLegacyFields_PreservesCuratedLowercaseEntries(t *testing.T) {
 	dir := t.TempDir()
 	outputPath := filepath.Join(dir, "const_fields.go")
 
@@ -304,7 +328,7 @@ var legacyDCGMFields = map[string]Short{
 // DCGM_FI_* uppercase entries in the existing output file are NOT
 // preserved. They re-derive from the header via resolveAliases, so stale
 // entries (aliases removed from the header) disappear naturally.
-func TestGenerateOutput_StaleGeneratedAliasNotPreserved(t *testing.T) {
+func TestExtractLegacyFields_StaleGeneratedAliasNotPreserved(t *testing.T) {
 	dir := t.TempDir()
 	outputPath := filepath.Join(dir, "const_fields.go")
 
@@ -357,5 +381,266 @@ var legacyDCGMFields = map[string]Short{
 	}
 	if !strings.Contains(err.Error(), "MYSTERY_UPPERCASE_NAME") {
 		t.Errorf("error should name the offending entry, got %q", err)
+	}
+}
+
+// A missing output file is normal on first-run; main() inspects the
+// returned error with os.IsNotExist and starts with an empty legacy map.
+func TestExtractLegacyFields_FileNotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, err := extractLegacyFields(filepath.Join(dir, "does-not-exist.go"))
+	if err == nil {
+		t.Fatalf("expected error on missing output file, got nil")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("error should satisfy os.IsNotExist so main can tolerate it; got %v", err)
+	}
+}
+
+// Mixed provenance in a single legacy map: lowercase preserved, DCGM_FI_*
+// dropped (re-derived by resolveAliases elsewhere), no error.
+func TestExtractLegacyFields_MixedEntriesReturnsOnlyLowercase(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "const_fields.go")
+
+	seeded := `package dcgm
+var legacyDCGMFields = map[string]Short{
+	"dcgm_gpu_temp": 150,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL": 449,
+	"dcgm_xid_errors": 230,
+}
+`
+	if err := os.WriteFile(outputPath, []byte(seeded), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	legacyFields, err := extractLegacyFields(outputPath)
+	if err != nil {
+		t.Fatalf("extractLegacyFields: %v", err)
+	}
+	if len(legacyFields) != 2 {
+		t.Fatalf("want exactly 2 preserved entries, got %d: %v", len(legacyFields), legacyFields)
+	}
+	if legacyFields["dcgm_gpu_temp"] != 150 || legacyFields["dcgm_xid_errors"] != 230 {
+		t.Errorf("lowercase entries not preserved correctly: %v", legacyFields)
+	}
+	if _, ok := legacyFields["DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"]; ok {
+		t.Errorf("DCGM_FI_* entry should have been dropped: %v", legacyFields)
+	}
+}
+
+// Bare alias inside #ifdef DCGM_DEPRECATED with no preceding comment: the
+// block scope alone is sufficient. This pins the `inDeprecatedBlock`
+// branch of the acceptance rule.
+func TestParseHeader_AliasInsideDeprecatedBlockWithoutComment_Accepted(t *testing.T) {
+	path := writeHeader(t, `
+#define DCGM_FI_DEV_CANONICAL 42
+
+#define DCGM_DEPRECATED
+
+#ifdef DCGM_DEPRECATED
+#define DCGM_FI_DEV_OLD_NAME DCGM_FI_DEV_CANONICAL
+#endif
+`)
+
+	_, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	if target, ok := aliases["DCGM_FI_DEV_OLD_NAME"]; !ok {
+		t.Errorf("bare alias inside deprecated block was dropped: %v", aliases)
+	} else if target != "DCGM_FI_DEV_CANONICAL" {
+		t.Errorf("wrong alias target: %q", target)
+	}
+}
+
+// A nested #ifdef/#endif inside the deprecated block must not prematurely
+// close it. An alias after the inner #endif but before the outer #endif
+// is still in deprecated scope.
+func TestParseHeader_NestedIfdefInsideDeprecatedBlock(t *testing.T) {
+	path := writeHeader(t, `
+#define DCGM_FI_DEV_CANONICAL 42
+
+#define DCGM_DEPRECATED
+
+#ifdef DCGM_DEPRECATED
+#ifdef SOME_UNRELATED_GUARD
+#define DCGM_FI_DEV_INNER_ALIAS DCGM_FI_DEV_CANONICAL
+#endif
+#define DCGM_FI_DEV_OUTER_ALIAS DCGM_FI_DEV_CANONICAL
+#endif
+`)
+
+	_, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	// Both aliases should be recorded: the inner one while the outer guard
+	// is active, the outer one after the inner #endif returns to the
+	// deprecated block but not out of it.
+	if _, ok := aliases["DCGM_FI_DEV_INNER_ALIAS"]; !ok {
+		t.Errorf("alias inside nested #ifdef not recorded: %v", aliases)
+	}
+	if _, ok := aliases["DCGM_FI_DEV_OUTER_ALIAS"]; !ok {
+		t.Errorf("alias after nested #endif but still inside deprecated block not recorded: %v", aliases)
+	}
+}
+
+// The "deprecated:" marker match is case-insensitive. A header that
+// capitalised the whole word should still trigger the heuristic.
+func TestParseHeader_CaseInsensitiveDeprecatedMarker(t *testing.T) {
+	path := writeHeader(t, `
+#define DCGM_FI_DEV_CANONICAL 42
+
+/**
+ * DEPRECATED: Use DCGM_FI_DEV_CANONICAL instead.
+ */
+#define DCGM_FI_DEV_OLD_UPPER DCGM_FI_DEV_CANONICAL
+
+/**
+ * deprecated: lowercase form also counts.
+ */
+#define DCGM_FI_DEV_OLD_LOWER DCGM_FI_DEV_CANONICAL
+`)
+
+	_, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	if _, ok := aliases["DCGM_FI_DEV_OLD_UPPER"]; !ok {
+		t.Errorf("uppercase DEPRECATED: did not trigger: %v", aliases)
+	}
+	if _, ok := aliases["DCGM_FI_DEV_OLD_LOWER"]; !ok {
+		t.Errorf("lowercase deprecated: did not trigger: %v", aliases)
+	}
+}
+
+// Adjectival uses of "deprecated" (without a trailing colon) must not
+// trigger the heuristic. The pattern is specifically "deprecated:" so
+// comments describing some other deprecation don't false-positive.
+func TestParseHeader_DeprecatedWordWithoutColon_DoesNotTrigger(t *testing.T) {
+	path := writeHeader(t, `
+#define DCGM_FI_DEV_CANONICAL 42
+
+/**
+ * This replaces the now-deprecated DCGM_FI_DEV_FOO field; no colon here.
+ */
+#define DCGM_FI_DEV_ALIAS DCGM_FI_DEV_CANONICAL
+`)
+
+	_, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	if _, ok := aliases["DCGM_FI_DEV_ALIAS"]; ok {
+		t.Errorf("adjectival 'deprecated' (no colon) false-positively triggered: %v", aliases)
+	}
+}
+
+// Blank lines between the closing */ and its described #define must
+// preserve the comment state so the comment still attaches to the field.
+// This is the common real-world header layout.
+func TestParseHeader_BlankLineBetweenCommentAndDefineAttaches(t *testing.T) {
+	path := writeHeader(t, `
+/**
+ * Field with blank line between comment and define.
+ */
+
+#define DCGM_FI_DEV_CANONICAL 42
+
+/**
+ * Deprecated: with blank line before alias too.
+ */
+
+#define DCGM_FI_DEV_OLD DCGM_FI_DEV_CANONICAL
+`)
+
+	fields, aliases, err := parseHeader(path)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+
+	f, ok := findField(fields, "DCGM_FI_DEV_CANONICAL")
+	if !ok || !strings.Contains(f.Comment, "blank line between comment and define") {
+		t.Errorf("comment did not attach across blank line: field=%+v", f)
+	}
+	if _, ok := aliases["DCGM_FI_DEV_OLD"]; !ok {
+		t.Errorf("deprecated: marker did not carry across blank line: %v", aliases)
+	}
+}
+
+// Full-pipeline integration: parseHeader -> resolveAliases ->
+// extractLegacyFields -> generateOutput. Reads the emitted file and
+// verifies the expected constants, canonical map entries, and legacy map
+// entries all land in the right sections.
+func TestGenerateOutput_FullPipeline(t *testing.T) {
+	dir := t.TempDir()
+	outputPath := filepath.Join(dir, "const_fields.go")
+
+	// Seed a pre-existing output with a curated lowercase legacy entry
+	// that the pipeline should preserve.
+	seeded := `package dcgm
+var legacyDCGMFields = map[string]Short{
+	"dcgm_gpu_temp": 150,
+}
+`
+	if err := os.WriteFile(outputPath, []byte(seeded), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	headerPath := writeHeader(t, `
+/**
+ * Canonical field.
+ */
+#define DCGM_FI_DEV_CANONICAL 42
+
+#define DCGM_DEPRECATED
+
+#ifdef DCGM_DEPRECATED
+#define DCGM_FI_DEV_OLD_ALIAS DCGM_FI_DEV_CANONICAL
+#endif
+`)
+
+	fields, aliases, err := parseHeader(headerPath)
+	if err != nil {
+		t.Fatalf("parseHeader: %v", err)
+	}
+	aliasLegacy, err := resolveAliases(fields, aliases)
+	if err != nil {
+		t.Fatalf("resolveAliases: %v", err)
+	}
+	legacyFields, err := extractLegacyFields(outputPath)
+	if err != nil {
+		t.Fatalf("extractLegacyFields: %v", err)
+	}
+	for name, id := range aliasLegacy {
+		legacyFields[name] = id
+	}
+
+	if err := generateOutput(TemplateData{Fields: fields, LegacyFields: legacyFields}, outputPath); err != nil {
+		t.Fatalf("generateOutput: %v", err)
+	}
+
+	out, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read emitted: %v", err)
+	}
+	got := string(out)
+
+	// Typed constant.
+	if !strings.Contains(got, "DCGM_FI_DEV_CANONICAL Short = 42") {
+		t.Errorf("canonical typed constant missing in output:\n%s", got)
+	}
+	// dcgmFields canonical entry.
+	if !strings.Contains(got, `"DCGM_FI_DEV_CANONICAL": 42`) {
+		t.Errorf("canonical entry missing from dcgmFields:\n%s", got)
+	}
+	// legacyDCGMFields alias entry.
+	if !strings.Contains(got, `"DCGM_FI_DEV_OLD_ALIAS": 42`) {
+		t.Errorf("deprecated alias missing from legacyDCGMFields:\n%s", got)
+	}
+	// legacyDCGMFields curated lowercase entry.
+	if !strings.Contains(got, `"dcgm_gpu_temp": 150`) {
+		t.Errorf("curated lowercase entry not preserved:\n%s", got)
 	}
 }

--- a/pkg/dcgm/alias_resolution_test.go
+++ b/pkg/dcgm/alias_resolution_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dcgm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Pure lookup tests against the generated dcgmFields / legacyDCGMFields maps.
+// No setupTest(t): these do not require a DCGM runtime. Precedent:
+// TestGetFieldIDBindUnbindEvent in bind_unbind_test.go.
+
+// Deprecated alias resolves via legacyDCGMFields to the same ID as its
+// canonical THROUGHPUT counterpart.
+func TestAliasResolution_NVLinkBandwidthTotalResolvesToThroughputTotal(t *testing.T) {
+	aliasID, aliasOK := GetFieldID("DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL")
+	require.True(t, aliasOK, "deprecated alias must be resolvable")
+
+	canonicalID, canonicalOK := GetFieldID("DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL")
+	require.True(t, canonicalOK, "canonical field must be resolvable")
+
+	assert.Equal(t, canonicalID, aliasID,
+		"deprecated alias must resolve to the same ID as its canonical target")
+}
+
+// The deprecated alias lives in the legacy map only.
+func TestAliasResolution_NVLinkBandwidthTotalIsLegacyOnly(t *testing.T) {
+	assert.True(t, IsLegacyField("DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"),
+		"deprecated alias must be marked legacy")
+	assert.False(t, IsCurrentField("DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL"),
+		"deprecated alias must not appear in the current-fields map")
+}
+
+// The canonical field is current, not legacy.
+func TestAliasResolution_CanonicalThroughputTotalIsCurrent(t *testing.T) {
+	assert.True(t, IsCurrentField("DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL"),
+		"canonical field must be marked current")
+	assert.False(t, IsLegacyField("DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL"),
+		"canonical field must not appear in the legacy map")
+}
+
+// Range sentinels like DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST are alias-style
+// #defines but are NOT deprecated. They must not be resolvable via the
+// public lookup API. A future change that naively resolves all aliases
+// would break this assertion.
+func TestAliasResolution_RangeSentinelIsNotResolvable(t *testing.T) {
+	_, ok := GetFieldID("DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST")
+	assert.False(t, ok,
+		"range sentinel (non-deprecated alias) must not resolve as a field name")
+}
+
+// Outside-the-#ifdef-block deprecated alias (CLOCK_THROTTLE_REASONS)
+// resolves via legacyDCGMFields to its canonical counterpart. Pins the
+// "Deprecated:" comment-heuristic end-to-end.
+func TestAliasResolution_ClockThrottleReasonsResolvesToClocksEventReasons(t *testing.T) {
+	aliasID, aliasOK := GetFieldID("DCGM_FI_DEV_CLOCK_THROTTLE_REASONS")
+	require.True(t, aliasOK, "outside-block deprecated alias must be resolvable")
+
+	canonicalID, canonicalOK := GetFieldID("DCGM_FI_DEV_CLOCKS_EVENT_REASONS")
+	require.True(t, canonicalOK, "canonical field must be resolvable")
+
+	assert.Equal(t, canonicalID, aliasID)
+	assert.True(t, IsLegacyField("DCGM_FI_DEV_CLOCK_THROTTLE_REASONS"),
+		"outside-block deprecated alias must be marked legacy")
+}

--- a/pkg/dcgm/alias_resolution_test.go
+++ b/pkg/dcgm/alias_resolution_test.go
@@ -80,3 +80,13 @@ func TestAliasResolution_ClockThrottleReasonsResolvesToClocksEventReasons(t *tes
 	assert.True(t, IsLegacyField("DCGM_FI_DEV_CLOCK_THROTTLE_REASONS"),
 		"outside-block deprecated alias must be marked legacy")
 }
+
+// GetFieldIDOrPanic must resolve a deprecated alias without panicking
+// (the existing panic path is reserved for unknown names).
+func TestAliasResolution_GetFieldIDOrPanicDoesNotPanicOnAlias(t *testing.T) {
+	assert.NotPanics(t, func() {
+		id := GetFieldIDOrPanic("DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL")
+		assert.Equal(t, GetFieldIDOrPanic("DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL"), id,
+			"GetFieldIDOrPanic on alias must return same ID as its canonical counterpart")
+	})
+}

--- a/pkg/dcgm/const_fields.go
+++ b/pkg/dcgm/const_fields.go
@@ -17,379 +17,379 @@
 package dcgm
 
 const (
-	// DCGM_FI_UNKNOWN represents /
+	// DCGM_FI_UNKNOWN represents NULL field
 	DCGM_FI_UNKNOWN Short = 0
-	// DCGM_FI_DRIVER_VERSION represents /
+	// DCGM_FI_DRIVER_VERSION represents Driver Version
 	DCGM_FI_DRIVER_VERSION Short = 1
 	// DCGM_FI_NVML_VERSION
 	DCGM_FI_NVML_VERSION Short = 2
-	// DCGM_FI_PROCESS_NAME represents /
+	// DCGM_FI_PROCESS_NAME represents Process Name
 	DCGM_FI_PROCESS_NAME Short = 3
-	// DCGM_FI_DEV_COUNT represents /
+	// DCGM_FI_DEV_COUNT represents Number of Devices on the node
 	DCGM_FI_DEV_COUNT Short = 4
-	// DCGM_FI_CUDA_DRIVER_VERSION represents /
+	// DCGM_FI_CUDA_DRIVER_VERSION represents CUDA 11.1 = 11100
 	DCGM_FI_CUDA_DRIVER_VERSION Short = 5
-	// DCGM_FI_BIND_UNBIND_EVENT represents /
+	// DCGM_FI_BIND_UNBIND_EVENT represents @note Recommended watch frequency: 1 second
 	DCGM_FI_BIND_UNBIND_EVENT Short = 6
-	// DCGM_FI_DEV_NAME represents /
+	// DCGM_FI_DEV_NAME represents Name of the GPU device
 	DCGM_FI_DEV_NAME Short = 50
-	// DCGM_FI_DEV_BRAND represents /
+	// DCGM_FI_DEV_BRAND represents Device Brand
 	DCGM_FI_DEV_BRAND Short = 51
-	// DCGM_FI_DEV_NVML_INDEX represents /
+	// DCGM_FI_DEV_NVML_INDEX represents NVML index of this GPU
 	DCGM_FI_DEV_NVML_INDEX Short = 52
-	// DCGM_FI_DEV_SERIAL represents /
+	// DCGM_FI_DEV_SERIAL represents Device Serial Number
 	DCGM_FI_DEV_SERIAL Short = 53
-	// DCGM_FI_DEV_UUID represents /
+	// DCGM_FI_DEV_UUID represents UUID corresponding to the device
 	DCGM_FI_DEV_UUID Short = 54
-	// DCGM_FI_DEV_MINOR_NUMBER represents /
+	// DCGM_FI_DEV_MINOR_NUMBER represents Device node minor number /dev/nvidia#
 	DCGM_FI_DEV_MINOR_NUMBER Short = 55
-	// DCGM_FI_DEV_OEM_INFOROM_VER represents /
+	// DCGM_FI_DEV_OEM_INFOROM_VER represents OEM inforom version
 	DCGM_FI_DEV_OEM_INFOROM_VER Short = 56
-	// DCGM_FI_DEV_PCI_BUSID represents /
+	// DCGM_FI_DEV_PCI_BUSID represents PCI attributes for the device
 	DCGM_FI_DEV_PCI_BUSID Short = 57
-	// DCGM_FI_DEV_PCI_COMBINED_ID represents /
+	// DCGM_FI_DEV_PCI_COMBINED_ID represents The combined 16-bit device id and 16-bit vendor id
 	DCGM_FI_DEV_PCI_COMBINED_ID Short = 58
-	// DCGM_FI_DEV_PCI_SUBSYS_ID represents /
+	// DCGM_FI_DEV_PCI_SUBSYS_ID represents The 32-bit Sub System Device ID
 	DCGM_FI_DEV_PCI_SUBSYS_ID Short = 59
-	// DCGM_FI_GPU_TOPOLOGY_PCI represents /
+	// DCGM_FI_GPU_TOPOLOGY_PCI represents Topology of all GPUs on the system via PCI (static)
 	DCGM_FI_GPU_TOPOLOGY_PCI Short = 60
-	// DCGM_FI_GPU_TOPOLOGY_NVLINK represents /
+	// DCGM_FI_GPU_TOPOLOGY_NVLINK represents Topology of all GPUs on the system via NVLINK (static)
 	DCGM_FI_GPU_TOPOLOGY_NVLINK Short = 61
-	// DCGM_FI_GPU_TOPOLOGY_AFFINITY represents /
+	// DCGM_FI_GPU_TOPOLOGY_AFFINITY represents Affinity of all GPUs on the system (static)
 	DCGM_FI_GPU_TOPOLOGY_AFFINITY Short = 62
-	// DCGM_FI_DEV_CUDA_COMPUTE_CAPABILITY represents /
+	// DCGM_FI_DEV_CUDA_COMPUTE_CAPABILITY represents the minor version is the lower 32 bits.
 	DCGM_FI_DEV_CUDA_COMPUTE_CAPABILITY Short = 63
-	// DCGM_FI_DEV_P2P_NVLINK_STATUS represents /
+	// DCGM_FI_DEV_P2P_NVLINK_STATUS represents A bitmap of the P2P NVLINK status from this GPU to others on this host.
 	DCGM_FI_DEV_P2P_NVLINK_STATUS Short = 64
-	// DCGM_FI_DEV_COMPUTE_MODE represents /
+	// DCGM_FI_DEV_COMPUTE_MODE represents Compute mode for the device
 	DCGM_FI_DEV_COMPUTE_MODE Short = 65
-	// DCGM_FI_DEV_PERSISTENCE_MODE represents /
+	// DCGM_FI_DEV_PERSISTENCE_MODE represents Boolean: 0 is disabled, 1 is enabled
 	DCGM_FI_DEV_PERSISTENCE_MODE Short = 66
-	// DCGM_FI_DEV_MIG_MODE represents /
+	// DCGM_FI_DEV_MIG_MODE represents Boolean: 0 is disabled, 1 is enabled
 	DCGM_FI_DEV_MIG_MODE Short = 67
-	// DCGM_FI_DEV_CUDA_VISIBLE_DEVICES_STR represents /
+	// DCGM_FI_DEV_CUDA_VISIBLE_DEVICES_STR represents be set to for this entity (including MIG)
 	DCGM_FI_DEV_CUDA_VISIBLE_DEVICES_STR Short = 68
-	// DCGM_FI_DEV_MIG_MAX_SLICES represents /
+	// DCGM_FI_DEV_MIG_MAX_SLICES represents The maximum number of MIG slices supported by this GPU
 	DCGM_FI_DEV_MIG_MAX_SLICES Short = 69
-	// DCGM_FI_DEV_CPU_AFFINITY_0 represents /
+	// DCGM_FI_DEV_CPU_AFFINITY_0 represents Device CPU affinity. part 1/8 = cpus 0 - 63
 	DCGM_FI_DEV_CPU_AFFINITY_0 Short = 70
-	// DCGM_FI_DEV_CPU_AFFINITY_1 represents /
+	// DCGM_FI_DEV_CPU_AFFINITY_1 represents Device CPU affinity. part 1/8 = cpus 64 - 127
 	DCGM_FI_DEV_CPU_AFFINITY_1 Short = 71
-	// DCGM_FI_DEV_CPU_AFFINITY_2 represents /
+	// DCGM_FI_DEV_CPU_AFFINITY_2 represents Device CPU affinity. part 2/8 = cpus 128 - 191
 	DCGM_FI_DEV_CPU_AFFINITY_2 Short = 72
-	// DCGM_FI_DEV_CPU_AFFINITY_3 represents /
+	// DCGM_FI_DEV_CPU_AFFINITY_3 represents Device CPU affinity. part 3/8 = cpus 192 - 255
 	DCGM_FI_DEV_CPU_AFFINITY_3 Short = 73
-	// DCGM_FI_DEV_CC_MODE represents /
+	// DCGM_FI_DEV_CC_MODE represents 1 = enabled
 	DCGM_FI_DEV_CC_MODE Short = 74
-	// DCGM_FI_DEV_MIG_ATTRIBUTES represents /
+	// DCGM_FI_DEV_MIG_ATTRIBUTES represents Attributes for the given MIG device handles
 	DCGM_FI_DEV_MIG_ATTRIBUTES Short = 75
-	// DCGM_FI_DEV_MIG_GI_INFO represents /
+	// DCGM_FI_DEV_MIG_GI_INFO represents GPU instance profile information
 	DCGM_FI_DEV_MIG_GI_INFO Short = 76
-	// DCGM_FI_DEV_MIG_CI_INFO represents /
+	// DCGM_FI_DEV_MIG_CI_INFO represents Compute instance profile information
 	DCGM_FI_DEV_MIG_CI_INFO Short = 77
-	// DCGM_FI_DEV_ECC_INFOROM_VER represents /
+	// DCGM_FI_DEV_ECC_INFOROM_VER represents ECC inforom version
 	DCGM_FI_DEV_ECC_INFOROM_VER Short = 80
-	// DCGM_FI_DEV_POWER_INFOROM_VER represents /
+	// DCGM_FI_DEV_POWER_INFOROM_VER represents Power management object inforom version
 	DCGM_FI_DEV_POWER_INFOROM_VER Short = 81
-	// DCGM_FI_DEV_INFOROM_IMAGE_VER represents /
+	// DCGM_FI_DEV_INFOROM_IMAGE_VER represents Inforom image version
 	DCGM_FI_DEV_INFOROM_IMAGE_VER Short = 82
-	// DCGM_FI_DEV_INFOROM_CONFIG_CHECK represents /
+	// DCGM_FI_DEV_INFOROM_CONFIG_CHECK represents Inforom configuration checksum
 	DCGM_FI_DEV_INFOROM_CONFIG_CHECK Short = 83
-	// DCGM_FI_DEV_INFOROM_CONFIG_VALID represents /
+	// DCGM_FI_DEV_INFOROM_CONFIG_VALID represents Reads the infoROM from the flash and verifies the checksums
 	DCGM_FI_DEV_INFOROM_CONFIG_VALID Short = 84
-	// DCGM_FI_DEV_VBIOS_VERSION represents /
+	// DCGM_FI_DEV_VBIOS_VERSION represents VBIOS version of the device
 	DCGM_FI_DEV_VBIOS_VERSION Short = 85
-	// DCGM_FI_DEV_MEM_AFFINITY_0 represents /
+	// DCGM_FI_DEV_MEM_AFFINITY_0 represents Device Memory node affinity, 0-63
 	DCGM_FI_DEV_MEM_AFFINITY_0 Short = 86
-	// DCGM_FI_DEV_MEM_AFFINITY_1 represents /
+	// DCGM_FI_DEV_MEM_AFFINITY_1 represents Device Memory node affinity, 64-127
 	DCGM_FI_DEV_MEM_AFFINITY_1 Short = 87
-	// DCGM_FI_DEV_MEM_AFFINITY_2 represents /
+	// DCGM_FI_DEV_MEM_AFFINITY_2 represents Device Memory node affinity, 128-191
 	DCGM_FI_DEV_MEM_AFFINITY_2 Short = 88
-	// DCGM_FI_DEV_MEM_AFFINITY_3 represents /
+	// DCGM_FI_DEV_MEM_AFFINITY_3 represents Device Memory node affinity, 192-255
 	DCGM_FI_DEV_MEM_AFFINITY_3 Short = 89
-	// DCGM_FI_DEV_BAR1_TOTAL represents /
+	// DCGM_FI_DEV_BAR1_TOTAL represents Total BAR1 of the GPU in MB
 	DCGM_FI_DEV_BAR1_TOTAL Short = 90
-	// DCGM_FI_SYNC_BOOST represents /
+	// DCGM_FI_SYNC_BOOST represents Deprecated - Sync boost settings on the node
 	DCGM_FI_SYNC_BOOST Short = 91
-	// DCGM_FI_DEV_BAR1_USED represents /
+	// DCGM_FI_DEV_BAR1_USED represents Used BAR1 of the GPU in MB
 	DCGM_FI_DEV_BAR1_USED Short = 92
-	// DCGM_FI_DEV_BAR1_FREE represents /
+	// DCGM_FI_DEV_BAR1_FREE represents Free BAR1 of the GPU in MB
 	DCGM_FI_DEV_BAR1_FREE Short = 93
-	// DCGM_FI_DEV_GPM_SUPPORT represents */
+	// DCGM_FI_DEV_GPM_SUPPORT represents * GPM support for the device
 	DCGM_FI_DEV_GPM_SUPPORT Short = 94
-	// DCGM_FI_DEV_SM_CLOCK represents /
+	// DCGM_FI_DEV_SM_CLOCK represents SM clock for the device
 	DCGM_FI_DEV_SM_CLOCK Short = 100
-	// DCGM_FI_DEV_MEM_CLOCK represents /
+	// DCGM_FI_DEV_MEM_CLOCK represents Memory clock for the device
 	DCGM_FI_DEV_MEM_CLOCK Short = 101
-	// DCGM_FI_DEV_VIDEO_CLOCK represents /
+	// DCGM_FI_DEV_VIDEO_CLOCK represents Video encoder/decoder clock for the device
 	DCGM_FI_DEV_VIDEO_CLOCK Short = 102
-	// DCGM_FI_DEV_APP_SM_CLOCK represents /
+	// DCGM_FI_DEV_APP_SM_CLOCK represents SM Application clocks
 	DCGM_FI_DEV_APP_SM_CLOCK Short = 110
-	// DCGM_FI_DEV_APP_MEM_CLOCK represents /
+	// DCGM_FI_DEV_APP_MEM_CLOCK represents Memory Application clocks
 	DCGM_FI_DEV_APP_MEM_CLOCK Short = 111
-	// DCGM_FI_DEV_CLOCKS_EVENT_REASONS represents /
+	// DCGM_FI_DEV_CLOCKS_EVENT_REASONS represents Current clock event reasons (bitmask of DCGM_CLOCKS_EVENT_REASON_*)
 	DCGM_FI_DEV_CLOCKS_EVENT_REASONS Short = 112
-	// DCGM_FI_DEV_MAX_SM_CLOCK represents /
+	// DCGM_FI_DEV_MAX_SM_CLOCK represents Maximum supported SM clock for the device
 	DCGM_FI_DEV_MAX_SM_CLOCK Short = 113
-	// DCGM_FI_DEV_MAX_MEM_CLOCK represents /
+	// DCGM_FI_DEV_MAX_MEM_CLOCK represents Maximum supported Memory clock for the device
 	DCGM_FI_DEV_MAX_MEM_CLOCK Short = 114
-	// DCGM_FI_DEV_MAX_VIDEO_CLOCK represents /
+	// DCGM_FI_DEV_MAX_VIDEO_CLOCK represents Maximum supported Video encoder/decoder clock for the device
 	DCGM_FI_DEV_MAX_VIDEO_CLOCK Short = 115
-	// DCGM_FI_DEV_AUTOBOOST represents /
+	// DCGM_FI_DEV_AUTOBOOST represents Auto-boost for the device (1 = enabled. 0 = disabled)
 	DCGM_FI_DEV_AUTOBOOST Short = 120
-	// DCGM_FI_DEV_SUPPORTED_CLOCKS represents /
+	// DCGM_FI_DEV_SUPPORTED_CLOCKS represents Supported clocks for the device
 	DCGM_FI_DEV_SUPPORTED_CLOCKS Short = 130
-	// DCGM_FI_DEV_MEMORY_TEMP represents /
+	// DCGM_FI_DEV_MEMORY_TEMP represents Memory temperature for the device
 	DCGM_FI_DEV_MEMORY_TEMP Short = 140
-	// DCGM_FI_DEV_GPU_TEMP represents /
+	// DCGM_FI_DEV_GPU_TEMP represents Current temperature readings for the device, in degrees C
 	DCGM_FI_DEV_GPU_TEMP Short = 150
-	// DCGM_FI_DEV_MEM_MAX_OP_TEMP represents /
+	// DCGM_FI_DEV_MEM_MAX_OP_TEMP represents Maximum operating temperature for the memory of this GPU. Above this temperature slowdown will occur.
 	DCGM_FI_DEV_MEM_MAX_OP_TEMP Short = 151
-	// DCGM_FI_DEV_GPU_MAX_OP_TEMP represents /
+	// DCGM_FI_DEV_GPU_MAX_OP_TEMP represents Maximum operating temperature for this GPU
 	DCGM_FI_DEV_GPU_MAX_OP_TEMP Short = 152
-	// DCGM_FI_DEV_GPU_TEMP_LIMIT represents /
+	// DCGM_FI_DEV_GPU_TEMP_LIMIT represents Thermal margin temperature (distance to nearest slowdown threshold) for this GPU
 	DCGM_FI_DEV_GPU_TEMP_LIMIT Short = 153
-	// DCGM_FI_DEV_POWER_USAGE represents /
+	// DCGM_FI_DEV_POWER_USAGE represents Power usage for the device in Watts
 	DCGM_FI_DEV_POWER_USAGE Short = 155
-	// DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION represents /
+	// DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION represents Total energy consumption for the GPU in mJ since the driver was last reloaded
 	DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION Short = 156
-	// DCGM_FI_DEV_POWER_USAGE_INSTANT represents /
+	// DCGM_FI_DEV_POWER_USAGE_INSTANT represents Current instantaneous power usage of the device in Watts
 	DCGM_FI_DEV_POWER_USAGE_INSTANT Short = 157
-	// DCGM_FI_DEV_SLOWDOWN_TEMP represents /
+	// DCGM_FI_DEV_SLOWDOWN_TEMP represents Slowdown temperature for the device
 	DCGM_FI_DEV_SLOWDOWN_TEMP Short = 158
-	// DCGM_FI_DEV_SHUTDOWN_TEMP represents /
+	// DCGM_FI_DEV_SHUTDOWN_TEMP represents Shutdown temperature for the device
 	DCGM_FI_DEV_SHUTDOWN_TEMP Short = 159
-	// DCGM_FI_DEV_POWER_MGMT_LIMIT represents /
+	// DCGM_FI_DEV_POWER_MGMT_LIMIT represents Current Power limit for the device
 	DCGM_FI_DEV_POWER_MGMT_LIMIT Short = 160
-	// DCGM_FI_DEV_POWER_MGMT_LIMIT_MIN represents /
+	// DCGM_FI_DEV_POWER_MGMT_LIMIT_MIN represents Minimum power management limit for the device
 	DCGM_FI_DEV_POWER_MGMT_LIMIT_MIN Short = 161
-	// DCGM_FI_DEV_POWER_MGMT_LIMIT_MAX represents /
+	// DCGM_FI_DEV_POWER_MGMT_LIMIT_MAX represents Maximum power management limit for the device
 	DCGM_FI_DEV_POWER_MGMT_LIMIT_MAX Short = 162
-	// DCGM_FI_DEV_POWER_MGMT_LIMIT_DEF represents /
+	// DCGM_FI_DEV_POWER_MGMT_LIMIT_DEF represents Default power management limit for the device
 	DCGM_FI_DEV_POWER_MGMT_LIMIT_DEF Short = 163
-	// DCGM_FI_DEV_ENFORCED_POWER_LIMIT represents /
+	// DCGM_FI_DEV_ENFORCED_POWER_LIMIT represents Effective power limit that the driver enforces after taking into account all limiters
 	DCGM_FI_DEV_ENFORCED_POWER_LIMIT Short = 164
-	// DCGM_FI_DEV_REQUESTED_POWER_PROFILE_MASK represents /
+	// DCGM_FI_DEV_REQUESTED_POWER_PROFILE_MASK represents Requested workload power profile mask(Blackwell and newer)
 	DCGM_FI_DEV_REQUESTED_POWER_PROFILE_MASK Short = 165
-	// DCGM_FI_DEV_ENFORCED_POWER_PROFILE_MASK represents /
+	// DCGM_FI_DEV_ENFORCED_POWER_PROFILE_MASK represents Enforced workload power profile mask(Blackwell and newer)
 	DCGM_FI_DEV_ENFORCED_POWER_PROFILE_MASK Short = 166
-	// DCGM_FI_DEV_VALID_POWER_PROFILE_MASK represents /
+	// DCGM_FI_DEV_VALID_POWER_PROFILE_MASK represents Requested workload power profile mask(Blackwell and newer)
 	DCGM_FI_DEV_VALID_POWER_PROFILE_MASK Short = 167
-	// DCGM_FI_DEV_FABRIC_MANAGER_STATUS represents /
+	// DCGM_FI_DEV_FABRIC_MANAGER_STATUS represents The status of the fabric manager - a value from dcgmFabricManagerStatus_t.
 	DCGM_FI_DEV_FABRIC_MANAGER_STATUS Short = 170
-	// DCGM_FI_DEV_FABRIC_MANAGER_ERROR_CODE represents /
+	// DCGM_FI_DEV_FABRIC_MANAGER_ERROR_CODE represents NOTE: this is not populated unless the fabric manager completed startup
 	DCGM_FI_DEV_FABRIC_MANAGER_ERROR_CODE Short = 171
-	// DCGM_FI_DEV_FABRIC_CLUSTER_UUID represents /
+	// DCGM_FI_DEV_FABRIC_CLUSTER_UUID represents The uuid of the cluster to which this GPU belongs
 	DCGM_FI_DEV_FABRIC_CLUSTER_UUID Short = 172
-	// DCGM_FI_DEV_FABRIC_CLIQUE_ID represents /
+	// DCGM_FI_DEV_FABRIC_CLIQUE_ID represents The ID of the fabric clique to which this GPU belongs
 	DCGM_FI_DEV_FABRIC_CLIQUE_ID Short = 173
-	// DCGM_FI_DEV_FABRIC_HEALTH_MASK represents /
+	// DCGM_FI_DEV_FABRIC_HEALTH_MASK represents Use DCGM_GPU_FABRIC_HEALTH_GET macro to get the different health statuses.
 	DCGM_FI_DEV_FABRIC_HEALTH_MASK Short = 174
-	// DCGM_FI_DEV_FABRIC_HEALTH_SUMMARY represents /
+	// DCGM_FI_DEV_FABRIC_HEALTH_SUMMARY represents - NVML_GPU_FABRIC_HEALTH_SUMMARY_LIMITED_CAPACITY (3)
 	DCGM_FI_DEV_FABRIC_HEALTH_SUMMARY Short = 175
-	// DCGM_FI_DEV_PSTATE represents /
+	// DCGM_FI_DEV_PSTATE represents Performance state (P-State) 0-15. 0=highest
 	DCGM_FI_DEV_PSTATE Short = 190
-	// DCGM_FI_DEV_FAN_SPEED represents /
+	// DCGM_FI_DEV_FAN_SPEED represents Fan speed for the device in percent 0-100
 	DCGM_FI_DEV_FAN_SPEED Short = 191
-	// DCGM_FI_DEV_PCIE_TX_THROUGHPUT represents /
+	// DCGM_FI_DEV_PCIE_TX_THROUGHPUT represents Deprecated: Use DCGM_FI_PROF_PCIE_TX_BYTES instead.
 	DCGM_FI_DEV_PCIE_TX_THROUGHPUT Short = 200
-	// DCGM_FI_DEV_PCIE_RX_THROUGHPUT represents /
+	// DCGM_FI_DEV_PCIE_RX_THROUGHPUT represents Deprecated: Use DCGM_FI_PROF_PCIE_RX_BYTES instead.
 	DCGM_FI_DEV_PCIE_RX_THROUGHPUT Short = 201
-	// DCGM_FI_DEV_PCIE_REPLAY_COUNTER represents /
+	// DCGM_FI_DEV_PCIE_REPLAY_COUNTER represents PCIe replay counter
 	DCGM_FI_DEV_PCIE_REPLAY_COUNTER Short = 202
-	// DCGM_FI_DEV_GPU_UTIL represents /
+	// DCGM_FI_DEV_GPU_UTIL represents GPU Utilization
 	DCGM_FI_DEV_GPU_UTIL Short = 203
-	// DCGM_FI_DEV_MEM_COPY_UTIL represents /
+	// DCGM_FI_DEV_MEM_COPY_UTIL represents Memory Utilization
 	DCGM_FI_DEV_MEM_COPY_UTIL Short = 204
-	// DCGM_FI_DEV_ACCOUNTING_DATA represents /
+	// DCGM_FI_DEV_ACCOUNTING_DATA represents running "nvidia-smi -am 1" as root on the same node the host engine is running on.
 	DCGM_FI_DEV_ACCOUNTING_DATA Short = 205
-	// DCGM_FI_DEV_ENC_UTIL represents /
+	// DCGM_FI_DEV_ENC_UTIL represents Encoder Utilization
 	DCGM_FI_DEV_ENC_UTIL Short = 206
-	// DCGM_FI_DEV_DEC_UTIL represents /
+	// DCGM_FI_DEV_DEC_UTIL represents Decoder Utilization
 	DCGM_FI_DEV_DEC_UTIL Short = 207
-	// DCGM_FI_DEV_XID_ERRORS represents /
+	// DCGM_FI_DEV_XID_ERRORS represents XID errors. The value is the specific XID error
 	DCGM_FI_DEV_XID_ERRORS Short = 230
-	// DCGM_FI_DEV_PCIE_MAX_LINK_GEN represents /
+	// DCGM_FI_DEV_PCIE_MAX_LINK_GEN represents PCIe Max Link Generation
 	DCGM_FI_DEV_PCIE_MAX_LINK_GEN Short = 235
-	// DCGM_FI_DEV_PCIE_MAX_LINK_WIDTH represents /
+	// DCGM_FI_DEV_PCIE_MAX_LINK_WIDTH represents PCIe Max Link Width
 	DCGM_FI_DEV_PCIE_MAX_LINK_WIDTH Short = 236
-	// DCGM_FI_DEV_PCIE_LINK_GEN represents /
+	// DCGM_FI_DEV_PCIE_LINK_GEN represents PCIe Current Link Generation
 	DCGM_FI_DEV_PCIE_LINK_GEN Short = 237
-	// DCGM_FI_DEV_PCIE_LINK_WIDTH represents /
+	// DCGM_FI_DEV_PCIE_LINK_WIDTH represents PCIe Current Link Width
 	DCGM_FI_DEV_PCIE_LINK_WIDTH Short = 238
-	// DCGM_FI_DEV_POWER_VIOLATION represents /
+	// DCGM_FI_DEV_POWER_VIOLATION represents Power Violation time in ns
 	DCGM_FI_DEV_POWER_VIOLATION Short = 240
-	// DCGM_FI_DEV_THERMAL_VIOLATION represents /
+	// DCGM_FI_DEV_THERMAL_VIOLATION represents Thermal Violation time in ns
 	DCGM_FI_DEV_THERMAL_VIOLATION Short = 241
-	// DCGM_FI_DEV_SYNC_BOOST_VIOLATION represents /
+	// DCGM_FI_DEV_SYNC_BOOST_VIOLATION represents Sync Boost Violation time in ns
 	DCGM_FI_DEV_SYNC_BOOST_VIOLATION Short = 242
-	// DCGM_FI_DEV_BOARD_LIMIT_VIOLATION represents /
+	// DCGM_FI_DEV_BOARD_LIMIT_VIOLATION represents Board violation limit.
 	DCGM_FI_DEV_BOARD_LIMIT_VIOLATION Short = 243
-	// DCGM_FI_DEV_LOW_UTIL_VIOLATION represents /
+	// DCGM_FI_DEV_LOW_UTIL_VIOLATION represents Low utilisation violation limit.
 	DCGM_FI_DEV_LOW_UTIL_VIOLATION Short = 244
-	// DCGM_FI_DEV_RELIABILITY_VIOLATION represents /
+	// DCGM_FI_DEV_RELIABILITY_VIOLATION represents Reliability violation limit.
 	DCGM_FI_DEV_RELIABILITY_VIOLATION Short = 245
-	// DCGM_FI_DEV_TOTAL_APP_CLOCKS_VIOLATION represents /
+	// DCGM_FI_DEV_TOTAL_APP_CLOCKS_VIOLATION represents App clock violation limit.
 	DCGM_FI_DEV_TOTAL_APP_CLOCKS_VIOLATION Short = 246
-	// DCGM_FI_DEV_TOTAL_BASE_CLOCKS_VIOLATION represents /
+	// DCGM_FI_DEV_TOTAL_BASE_CLOCKS_VIOLATION represents Base clock violation limit.
 	DCGM_FI_DEV_TOTAL_BASE_CLOCKS_VIOLATION Short = 247
-	// DCGM_FI_DEV_FB_TOTAL represents /
+	// DCGM_FI_DEV_FB_TOTAL represents Total Frame Buffer of the GPU in MB
 	DCGM_FI_DEV_FB_TOTAL Short = 250
-	// DCGM_FI_DEV_FB_FREE represents /
+	// DCGM_FI_DEV_FB_FREE represents Free Frame Buffer in MB
 	DCGM_FI_DEV_FB_FREE Short = 251
-	// DCGM_FI_DEV_FB_USED represents /
+	// DCGM_FI_DEV_FB_USED represents Used Frame Buffer in MB
 	DCGM_FI_DEV_FB_USED Short = 252
-	// DCGM_FI_DEV_FB_RESERVED represents /
+	// DCGM_FI_DEV_FB_RESERVED represents Reserved Frame Buffer in MB
 	DCGM_FI_DEV_FB_RESERVED Short = 253
-	// DCGM_FI_DEV_FB_USED_PERCENT represents /
+	// DCGM_FI_DEV_FB_USED_PERCENT represents Percentage used of Frame Buffer: 'Used/(Total - Reserved)'. Range 0.0-1.0
 	DCGM_FI_DEV_FB_USED_PERCENT Short = 254
-	// DCGM_FI_DEV_C2C_LINK_COUNT represents /
+	// DCGM_FI_DEV_C2C_LINK_COUNT represents C2C Link Count
 	DCGM_FI_DEV_C2C_LINK_COUNT Short = 285
-	// DCGM_FI_DEV_C2C_LINK_STATUS represents /
+	// DCGM_FI_DEV_C2C_LINK_STATUS represents The value of 1 the link is ACTIVE.
 	DCGM_FI_DEV_C2C_LINK_STATUS Short = 286
-	// DCGM_FI_DEV_C2C_MAX_BANDWIDTH represents /
+	// DCGM_FI_DEV_C2C_MAX_BANDWIDTH represents The value indicates the link speed in MB/s.
 	DCGM_FI_DEV_C2C_MAX_BANDWIDTH Short = 287
-	// DCGM_FI_DEV_ECC_CURRENT represents /
+	// DCGM_FI_DEV_ECC_CURRENT represents Current ECC mode for the device
 	DCGM_FI_DEV_ECC_CURRENT Short = 300
-	// DCGM_FI_DEV_ECC_PENDING represents /
+	// DCGM_FI_DEV_ECC_PENDING represents Pending ECC mode for the device
 	DCGM_FI_DEV_ECC_PENDING Short = 301
-	// DCGM_FI_DEV_ECC_SBE_VOL_TOTAL represents /
+	// DCGM_FI_DEV_ECC_SBE_VOL_TOTAL represents Total single bit volatile ECC errors
 	DCGM_FI_DEV_ECC_SBE_VOL_TOTAL Short = 310
-	// DCGM_FI_DEV_ECC_DBE_VOL_TOTAL represents /
+	// DCGM_FI_DEV_ECC_DBE_VOL_TOTAL represents Total double bit volatile ECC errors
 	DCGM_FI_DEV_ECC_DBE_VOL_TOTAL Short = 311
-	// DCGM_FI_DEV_ECC_SBE_AGG_TOTAL represents /
+	// DCGM_FI_DEV_ECC_SBE_AGG_TOTAL represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_SBE_AGG_TOTAL Short = 312
-	// DCGM_FI_DEV_ECC_DBE_AGG_TOTAL represents /
+	// DCGM_FI_DEV_ECC_DBE_AGG_TOTAL represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_DBE_AGG_TOTAL Short = 313
-	// DCGM_FI_DEV_ECC_SBE_VOL_L1 represents /
+	// DCGM_FI_DEV_ECC_SBE_VOL_L1 represents L1 cache single bit volatile ECC errors
 	DCGM_FI_DEV_ECC_SBE_VOL_L1 Short = 314
-	// DCGM_FI_DEV_ECC_DBE_VOL_L1 represents /
+	// DCGM_FI_DEV_ECC_DBE_VOL_L1 represents L1 cache double bit volatile ECC errors
 	DCGM_FI_DEV_ECC_DBE_VOL_L1 Short = 315
-	// DCGM_FI_DEV_ECC_SBE_VOL_L2 represents /
+	// DCGM_FI_DEV_ECC_SBE_VOL_L2 represents L2 cache single bit volatile ECC errors
 	DCGM_FI_DEV_ECC_SBE_VOL_L2 Short = 316
-	// DCGM_FI_DEV_ECC_DBE_VOL_L2 represents /
+	// DCGM_FI_DEV_ECC_DBE_VOL_L2 represents L2 cache double bit volatile ECC errors
 	DCGM_FI_DEV_ECC_DBE_VOL_L2 Short = 317
-	// DCGM_FI_DEV_ECC_SBE_VOL_DEV represents /
+	// DCGM_FI_DEV_ECC_SBE_VOL_DEV represents Device memory single bit volatile ECC errors
 	DCGM_FI_DEV_ECC_SBE_VOL_DEV Short = 318
-	// DCGM_FI_DEV_ECC_DBE_VOL_DEV represents /
+	// DCGM_FI_DEV_ECC_DBE_VOL_DEV represents Device memory double bit volatile ECC errors
 	DCGM_FI_DEV_ECC_DBE_VOL_DEV Short = 319
-	// DCGM_FI_DEV_ECC_SBE_VOL_REG represents /
+	// DCGM_FI_DEV_ECC_SBE_VOL_REG represents Register file single bit volatile ECC errors
 	DCGM_FI_DEV_ECC_SBE_VOL_REG Short = 320
-	// DCGM_FI_DEV_ECC_DBE_VOL_REG represents /
+	// DCGM_FI_DEV_ECC_DBE_VOL_REG represents Register file double bit volatile ECC errors
 	DCGM_FI_DEV_ECC_DBE_VOL_REG Short = 321
-	// DCGM_FI_DEV_ECC_SBE_VOL_TEX represents /
+	// DCGM_FI_DEV_ECC_SBE_VOL_TEX represents Texture memory single bit volatile ECC errors
 	DCGM_FI_DEV_ECC_SBE_VOL_TEX Short = 322
-	// DCGM_FI_DEV_ECC_DBE_VOL_TEX represents /
+	// DCGM_FI_DEV_ECC_DBE_VOL_TEX represents Texture memory double bit volatile ECC errors
 	DCGM_FI_DEV_ECC_DBE_VOL_TEX Short = 323
-	// DCGM_FI_DEV_ECC_SBE_AGG_L1 represents /
+	// DCGM_FI_DEV_ECC_SBE_AGG_L1 represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_SBE_AGG_L1 Short = 324
-	// DCGM_FI_DEV_ECC_DBE_AGG_L1 represents /
+	// DCGM_FI_DEV_ECC_DBE_AGG_L1 represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_DBE_AGG_L1 Short = 325
-	// DCGM_FI_DEV_ECC_SBE_AGG_L2 represents /
+	// DCGM_FI_DEV_ECC_SBE_AGG_L2 represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_SBE_AGG_L2 Short = 326
-	// DCGM_FI_DEV_ECC_DBE_AGG_L2 represents /
+	// DCGM_FI_DEV_ECC_DBE_AGG_L2 represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_DBE_AGG_L2 Short = 327
-	// DCGM_FI_DEV_ECC_SBE_AGG_DEV represents /
+	// DCGM_FI_DEV_ECC_SBE_AGG_DEV represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_SBE_AGG_DEV Short = 328
-	// DCGM_FI_DEV_ECC_DBE_AGG_DEV represents /
+	// DCGM_FI_DEV_ECC_DBE_AGG_DEV represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_DBE_AGG_DEV Short = 329
-	// DCGM_FI_DEV_ECC_SBE_AGG_REG represents /
+	// DCGM_FI_DEV_ECC_SBE_AGG_REG represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_SBE_AGG_REG Short = 330
-	// DCGM_FI_DEV_ECC_DBE_AGG_REG represents /
+	// DCGM_FI_DEV_ECC_DBE_AGG_REG represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_DBE_AGG_REG Short = 331
-	// DCGM_FI_DEV_ECC_SBE_AGG_TEX represents /
+	// DCGM_FI_DEV_ECC_SBE_AGG_TEX represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_SBE_AGG_TEX Short = 332
-	// DCGM_FI_DEV_ECC_DBE_AGG_TEX represents /
+	// DCGM_FI_DEV_ECC_DBE_AGG_TEX represents Note: monotonically increasing
 	DCGM_FI_DEV_ECC_DBE_AGG_TEX Short = 333
-	// DCGM_FI_DEV_ECC_SBE_VOL_SHM represents /
+	// DCGM_FI_DEV_ECC_SBE_VOL_SHM represents Texture SHM single bit volatile ECC errors
 	DCGM_FI_DEV_ECC_SBE_VOL_SHM Short = 334
-	// DCGM_FI_DEV_ECC_DBE_VOL_SHM represents /
+	// DCGM_FI_DEV_ECC_DBE_VOL_SHM represents Texture SHM double bit volatile ECC errors
 	DCGM_FI_DEV_ECC_DBE_VOL_SHM Short = 335
-	// DCGM_FI_DEV_ECC_SBE_VOL_CBU represents /
+	// DCGM_FI_DEV_ECC_SBE_VOL_CBU represents CBU single bit ECC volatile errors
 	DCGM_FI_DEV_ECC_SBE_VOL_CBU Short = 336
-	// DCGM_FI_DEV_ECC_DBE_VOL_CBU represents /
+	// DCGM_FI_DEV_ECC_DBE_VOL_CBU represents CBU double bit ECC volatile errors
 	DCGM_FI_DEV_ECC_DBE_VOL_CBU Short = 337
-	// DCGM_FI_DEV_ECC_SBE_AGG_SHM represents /
+	// DCGM_FI_DEV_ECC_SBE_AGG_SHM represents Texture SHM single bit aggregate ECC errors
 	DCGM_FI_DEV_ECC_SBE_AGG_SHM Short = 338
-	// DCGM_FI_DEV_ECC_DBE_AGG_SHM represents /
+	// DCGM_FI_DEV_ECC_DBE_AGG_SHM represents Texture SHM double bit aggregate ECC errors
 	DCGM_FI_DEV_ECC_DBE_AGG_SHM Short = 339
-	// DCGM_FI_DEV_ECC_SBE_AGG_CBU represents /
+	// DCGM_FI_DEV_ECC_SBE_AGG_CBU represents CBU single bit ECC aggregate errors
 	DCGM_FI_DEV_ECC_SBE_AGG_CBU Short = 340
-	// DCGM_FI_DEV_ECC_DBE_AGG_CBU represents /
+	// DCGM_FI_DEV_ECC_DBE_AGG_CBU represents CBU double bit ECC aggregate errors
 	DCGM_FI_DEV_ECC_DBE_AGG_CBU Short = 341
-	// DCGM_FI_DEV_ECC_SBE_VOL_SRM represents /
+	// DCGM_FI_DEV_ECC_SBE_VOL_SRM represents SRAM single bit ECC volatile errors
 	DCGM_FI_DEV_ECC_SBE_VOL_SRM Short = 342
-	// DCGM_FI_DEV_ECC_DBE_VOL_SRM represents /
+	// DCGM_FI_DEV_ECC_DBE_VOL_SRM represents SRAM double bit ECC volatile errors
 	DCGM_FI_DEV_ECC_DBE_VOL_SRM Short = 343
-	// DCGM_FI_DEV_ECC_SBE_AGG_SRM represents /
+	// DCGM_FI_DEV_ECC_SBE_AGG_SRM represents SRAM single bit ECC aggregate errors
 	DCGM_FI_DEV_ECC_SBE_AGG_SRM Short = 344
-	// DCGM_FI_DEV_ECC_DBE_AGG_SRM represents /
+	// DCGM_FI_DEV_ECC_DBE_AGG_SRM represents SRAM double bit ECC aggregate errors
 	DCGM_FI_DEV_ECC_DBE_AGG_SRM Short = 345
-	// DCGM_FI_DEV_THRESHOLD_SRM represents /
+	// DCGM_FI_DEV_THRESHOLD_SRM represents SRAM Threashhold Exceeded boolean (1=true)
 	DCGM_FI_DEV_THRESHOLD_SRM Short = 346
-	// DCGM_FI_DEV_DIAG_MEMORY_RESULT represents /
+	// DCGM_FI_DEV_DIAG_MEMORY_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_MEMORY_RESULT Short = 350
-	// DCGM_FI_DEV_DIAG_DIAGNOSTIC_RESULT represents /
+	// DCGM_FI_DEV_DIAG_DIAGNOSTIC_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_DIAGNOSTIC_RESULT Short = 351
-	// DCGM_FI_DEV_DIAG_PCIE_RESULT represents /
+	// DCGM_FI_DEV_DIAG_PCIE_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_PCIE_RESULT Short = 352
-	// DCGM_FI_DEV_DIAG_TARGETED_STRESS_RESULT represents /
+	// DCGM_FI_DEV_DIAG_TARGETED_STRESS_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_TARGETED_STRESS_RESULT Short = 353
-	// DCGM_FI_DEV_DIAG_TARGETED_POWER_RESULT represents /
+	// DCGM_FI_DEV_DIAG_TARGETED_POWER_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_TARGETED_POWER_RESULT Short = 354
-	// DCGM_FI_DEV_DIAG_MEMORY_BANDWIDTH_RESULT represents /
+	// DCGM_FI_DEV_DIAG_MEMORY_BANDWIDTH_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_MEMORY_BANDWIDTH_RESULT Short = 355
-	// DCGM_FI_DEV_DIAG_MEMTEST_RESULT represents /
+	// DCGM_FI_DEV_DIAG_MEMTEST_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_MEMTEST_RESULT Short = 356
-	// DCGM_FI_DEV_DIAG_PULSE_TEST_RESULT represents /
+	// DCGM_FI_DEV_DIAG_PULSE_TEST_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_PULSE_TEST_RESULT Short = 357
-	// DCGM_FI_DEV_DIAG_EUD_RESULT represents /
+	// DCGM_FI_DEV_DIAG_EUD_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_EUD_RESULT Short = 358
-	// DCGM_FI_DEV_DIAG_CPU_EUD_RESULT represents /
+	// DCGM_FI_DEV_DIAG_CPU_EUD_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_CPU_EUD_RESULT Short = 359
-	// DCGM_FI_DEV_DIAG_SOFTWARE_RESULT represents /
+	// DCGM_FI_DEV_DIAG_SOFTWARE_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_SOFTWARE_RESULT Short = 360
-	// DCGM_FI_DEV_DIAG_NVBANDWIDTH_RESULT represents /
+	// DCGM_FI_DEV_DIAG_NVBANDWIDTH_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_NVBANDWIDTH_RESULT Short = 361
-	// DCGM_FI_DEV_DIAG_STATUS represents /
+	// DCGM_FI_DEV_DIAG_STATUS represents Refers to a binary blob of a `dcgmDiagStatus_t` struct
 	DCGM_FI_DEV_DIAG_STATUS Short = 362
-	// DCGM_FI_DEV_DIAG_NCCL_TESTS_RESULT represents /
+	// DCGM_FI_DEV_DIAG_NCCL_TESTS_RESULT represents Refers to a `int64_t` storing a value drawn from `dcgmError_t` enumeration
 	DCGM_FI_DEV_DIAG_NCCL_TESTS_RESULT Short = 363
-	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_MAX represents /
+	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_MAX represents Historical max available spare memory rows per memory bank
 	DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_MAX Short = 385
-	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_HIGH represents /
+	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_HIGH represents Historical high mark of available spare memory rows per memory bank
 	DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_HIGH Short = 386
-	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_PARTIAL represents /
+	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_PARTIAL represents Historical mark of partial available spare memory rows per memory bank
 	DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_PARTIAL Short = 387
-	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_LOW represents /
+	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_LOW represents Historical low mark of available spare memory rows per memory bank
 	DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_LOW Short = 388
-	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_NONE represents /
+	// DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_NONE represents Historical marker of memory banks with no available spare memory rows
 	DCGM_FI_DEV_BANKS_REMAP_ROWS_AVAIL_NONE Short = 389
-	// DCGM_FI_DEV_RETIRED_SBE represents /
+	// DCGM_FI_DEV_RETIRED_SBE represents Note: monotonically increasing
 	DCGM_FI_DEV_RETIRED_SBE Short = 390
-	// DCGM_FI_DEV_RETIRED_DBE represents /
+	// DCGM_FI_DEV_RETIRED_DBE represents Note: monotonically increasing
 	DCGM_FI_DEV_RETIRED_DBE Short = 391
-	// DCGM_FI_DEV_RETIRED_PENDING represents /
+	// DCGM_FI_DEV_RETIRED_PENDING represents Number of pages pending retirement
 	DCGM_FI_DEV_RETIRED_PENDING Short = 392
-	// DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS represents /
+	// DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS represents Number of remapped rows for uncorrectable errors
 	DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS Short = 393
-	// DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS represents /
+	// DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS represents Number of remapped rows for correctable errors
 	DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS Short = 394
-	// DCGM_FI_DEV_ROW_REMAP_FAILURE represents /
+	// DCGM_FI_DEV_ROW_REMAP_FAILURE represents Whether remapping of rows has failed
 	DCGM_FI_DEV_ROW_REMAP_FAILURE Short = 395
-	// DCGM_FI_DEV_ROW_REMAP_PENDING represents /
+	// DCGM_FI_DEV_ROW_REMAP_PENDING represents Whether remapping of rows is pending
 	DCGM_FI_DEV_ROW_REMAP_PENDING Short = 396
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L0 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L0 represents NV Link flow control CRC  Error Counter for Lane 0
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L0 Short = 400
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L1 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L1 represents NV Link flow control CRC  Error Counter for Lane 1
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L1 Short = 401
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L2 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L2 represents NV Link flow control CRC  Error Counter for Lane 2
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L2 Short = 402
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L3 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L3 represents NV Link flow control CRC  Error Counter for Lane 3
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L3 Short = 403
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L4 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L4 represents NV Link flow control CRC  Error Counter for Lane 4
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L4 Short = 404
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L5 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L5 represents NV Link flow control CRC  Error Counter for Lane 5
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L5 Short = 405
 	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L12
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L12 Short = 406
@@ -397,19 +397,19 @@ const (
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L13 Short = 407
 	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L14
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L14 Short = 408
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL represents NV Link flow control CRC  Error Counter total for all Lanes
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_TOTAL Short = 409
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L0 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L0 represents NV Link data CRC Error Counter for Lane 0
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L0 Short = 410
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L1 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L1 represents NV Link data CRC Error Counter for Lane 1
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L1 Short = 411
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L2 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L2 represents NV Link data CRC Error Counter for Lane 2
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L2 Short = 412
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L3 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L3 represents NV Link data CRC Error Counter for Lane 3
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L3 Short = 413
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L4 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L4 represents NV Link data CRC Error Counter for Lane 4
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L4 Short = 414
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L5 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L5 represents NV Link data CRC Error Counter for Lane 5
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L5 Short = 415
 	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L12
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L12 Short = 416
@@ -417,19 +417,19 @@ const (
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L13 Short = 417
 	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L14
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L14 Short = 418
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL represents NV Link data CRC Error Counter total for all Lanes
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_TOTAL Short = 419
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L0 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L0 represents NV Link Replay Error Counter for Lane 0
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L0 Short = 420
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L1 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L1 represents NV Link Replay Error Counter for Lane 1
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L1 Short = 421
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L2 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L2 represents NV Link Replay Error Counter for Lane 2
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L2 Short = 422
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L3 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L3 represents NV Link Replay Error Counter for Lane 3
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L3 Short = 423
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L4 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L4 represents NV Link Replay Error Counter for Lane 4
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L4 Short = 424
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L5 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L5 represents NV Link Replay Error Counter for Lane 5
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L5 Short = 425
 	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L12
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L12 Short = 426
@@ -437,19 +437,19 @@ const (
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L13 Short = 427
 	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L14
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L14 Short = 428
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL represents NV Link Replay Error Counter total for all Lanes
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_TOTAL Short = 429
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L0 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L0 represents NV Link Recovery Error Counter for Lane 0
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L0 Short = 430
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L1 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L1 represents NV Link Recovery Error Counter for Lane 1
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L1 Short = 431
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L2 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L2 represents NV Link Recovery Error Counter for Lane 2
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L2 Short = 432
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L3 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L3 represents NV Link Recovery Error Counter for Lane 3
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L3 Short = 433
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L4 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L4 represents NV Link Recovery Error Counter for Lane 4
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L4 Short = 434
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L5 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L5 represents NV Link Recovery Error Counter for Lane 5
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L5 Short = 435
 	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L12
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L12 Short = 436
@@ -457,19 +457,19 @@ const (
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L13 Short = 437
 	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L14
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L14 Short = 438
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL represents NV Link Recovery Error Counter total for all Lanes
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_TOTAL Short = 439
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L0 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L0 represents NV Link Throughput for Lane 0
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L0 Short = 440
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L1 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L1 represents NV Link Throughput for Lane 1
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L1 Short = 441
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L2 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L2 represents NV Link Throughput for Lane 2
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L2 Short = 442
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L3 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L3 represents NV Link Throughput for Lane 3
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L3 Short = 443
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L4 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L4 represents NV Link Throughput for Lane 4
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L4 Short = 444
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L5 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L5 represents NV Link Throughput for Lane 5
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L5 Short = 445
 	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L12
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L12 Short = 446
@@ -477,69 +477,69 @@ const (
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L13 Short = 447
 	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L14
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L14 Short = 448
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL represents NV Link Throughput total for all Lanes
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_TOTAL Short = 449
-	// DCGM_FI_DEV_GPU_NVLINK_ERRORS represents /
+	// DCGM_FI_DEV_GPU_NVLINK_ERRORS represents GPU NVLink error information
 	DCGM_FI_DEV_GPU_NVLINK_ERRORS Short = 450
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L6 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L6 represents NV Link flow control CRC  Error Counter for Lane 6
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L6 Short = 451
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L7 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L7 represents NV Link flow control CRC  Error Counter for Lane 7
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L7 Short = 452
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L8 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L8 represents NV Link flow control CRC  Error Counter for Lane 8
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L8 Short = 453
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L9 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L9 represents NV Link flow control CRC  Error Counter for Lane 9
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L9 Short = 454
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L10 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L10 represents NV Link flow control CRC  Error Counter for Lane 10
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L10 Short = 455
-	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L11 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L11 represents NV Link flow control CRC  Error Counter for Lane 11
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L11 Short = 456
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L6 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L6 represents NV Link data CRC Error Counter for Lane 6
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L6 Short = 457
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L7 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L7 represents NV Link data CRC Error Counter for Lane 7
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L7 Short = 458
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L8 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L8 represents NV Link data CRC Error Counter for Lane 8
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L8 Short = 459
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L9 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L9 represents NV Link data CRC Error Counter for Lane 9
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L9 Short = 460
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L10 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L10 represents NV Link data CRC Error Counter for Lane 10
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L10 Short = 461
-	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L11 represents /
+	// DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L11 represents NV Link data CRC Error Counter for Lane 11
 	DCGM_FI_DEV_NVLINK_CRC_DATA_ERROR_COUNT_L11 Short = 462
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L6 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L6 represents NV Link Replay Error Counter for Lane 6
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L6 Short = 463
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L7 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L7 represents NV Link Replay Error Counter for Lane 7
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L7 Short = 464
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L8 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L8 represents NV Link Replay Error Counter for Lane 8
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L8 Short = 465
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L9 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L9 represents NV Link Replay Error Counter for Lane 9
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L9 Short = 466
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L10 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L10 represents NV Link Replay Error Counter for Lane 10
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L10 Short = 467
-	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L11 represents /
+	// DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L11 represents NV Link Replay Error Counter for Lane 11
 	DCGM_FI_DEV_NVLINK_REPLAY_ERROR_COUNT_L11 Short = 468
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L6 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L6 represents NV Link Recovery Error Counter for Lane 6
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L6 Short = 469
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L7 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L7 represents NV Link Recovery Error Counter for Lane 7
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L7 Short = 470
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L8 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L8 represents NV Link Recovery Error Counter for Lane 8
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L8 Short = 471
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L9 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L9 represents NV Link Recovery Error Counter for Lane 9
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L9 Short = 472
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L10 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L10 represents NV Link Recovery Error Counter for Lane 10
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L10 Short = 473
-	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L11 represents /
+	// DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L11 represents NV Link Recovery Error Counter for Lane 11
 	DCGM_FI_DEV_NVLINK_RECOVERY_ERROR_COUNT_L11 Short = 474
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L6 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L6 represents NV Link Throughput for Lane 6
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L6 Short = 475
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L7 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L7 represents NV Link Throughput for Lane 7
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L7 Short = 476
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L8 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L8 represents NV Link Throughput for Lane 8
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L8 Short = 477
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L9 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L9 represents NV Link Throughput for Lane 9
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L9 Short = 478
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L10 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L10 represents NV Link Throughput for Lane 10
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L10 Short = 479
-	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L11 represents /
+	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L11 represents NV Link Throughput for Lane 11
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L11 Short = 480
 	// DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L15
 	DCGM_FI_DEV_NVLINK_CRC_FLIT_ERROR_COUNT_L15 Short = 481
@@ -571,381 +571,381 @@ const (
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L16 Short = 495
 	// DCGM_FI_DEV_NVLINK_THROUGHPUT_L17
 	DCGM_FI_DEV_NVLINK_THROUGHPUT_L17 Short = 496
-	// DCGM_FI_DEV_NVLINK_ERROR_DL_CRC represents /
+	// DCGM_FI_DEV_NVLINK_ERROR_DL_CRC represents NVLink CRC Error Counter
 	DCGM_FI_DEV_NVLINK_ERROR_DL_CRC Short = 497
-	// DCGM_FI_DEV_NVLINK_ERROR_DL_RECOVERY represents /
+	// DCGM_FI_DEV_NVLINK_ERROR_DL_RECOVERY represents NVLink Recovery Error Counter
 	DCGM_FI_DEV_NVLINK_ERROR_DL_RECOVERY Short = 498
-	// DCGM_FI_DEV_NVLINK_ERROR_DL_REPLAY represents /
+	// DCGM_FI_DEV_NVLINK_ERROR_DL_REPLAY represents NVLink Replay Error Counter
 	DCGM_FI_DEV_NVLINK_ERROR_DL_REPLAY Short = 499
-	// DCGM_FI_DEV_VIRTUAL_MODE represents /
+	// DCGM_FI_DEV_VIRTUAL_MODE represents One of DCGM_GPU_VIRTUALIZATION_MODE_* constants.
 	DCGM_FI_DEV_VIRTUAL_MODE Short = 500
-	// DCGM_FI_DEV_SUPPORTED_TYPE_INFO represents /
+	// DCGM_FI_DEV_SUPPORTED_TYPE_INFO represents Includes Count and Static info of vGPU types supported on a device
 	DCGM_FI_DEV_SUPPORTED_TYPE_INFO Short = 501
-	// DCGM_FI_DEV_CREATABLE_VGPU_TYPE_IDS represents /
+	// DCGM_FI_DEV_CREATABLE_VGPU_TYPE_IDS represents Includes Count and currently Creatable vGPU types on a device
 	DCGM_FI_DEV_CREATABLE_VGPU_TYPE_IDS Short = 502
-	// DCGM_FI_DEV_VGPU_INSTANCE_IDS represents /
+	// DCGM_FI_DEV_VGPU_INSTANCE_IDS represents Includes Count and currently Active vGPU Instances on a device
 	DCGM_FI_DEV_VGPU_INSTANCE_IDS Short = 503
-	// DCGM_FI_DEV_VGPU_UTILIZATIONS represents /
+	// DCGM_FI_DEV_VGPU_UTILIZATIONS represents Utilization values for vGPUs running on the device
 	DCGM_FI_DEV_VGPU_UTILIZATIONS Short = 504
-	// DCGM_FI_DEV_VGPU_PER_PROCESS_UTILIZATION represents /
+	// DCGM_FI_DEV_VGPU_PER_PROCESS_UTILIZATION represents Utilization values for processes running within vGPU VMs using the device
 	DCGM_FI_DEV_VGPU_PER_PROCESS_UTILIZATION Short = 505
-	// DCGM_FI_DEV_ENC_STATS represents /
+	// DCGM_FI_DEV_ENC_STATS represents Current encoder statistics for a given device
 	DCGM_FI_DEV_ENC_STATS Short = 506
-	// DCGM_FI_DEV_FBC_STATS represents /
+	// DCGM_FI_DEV_FBC_STATS represents Statistics of current active frame buffer capture sessions on a given device
 	DCGM_FI_DEV_FBC_STATS Short = 507
-	// DCGM_FI_DEV_FBC_SESSIONS_INFO represents /
+	// DCGM_FI_DEV_FBC_SESSIONS_INFO represents Information about active frame buffer capture sessions on a target device
 	DCGM_FI_DEV_FBC_SESSIONS_INFO Short = 508
-	// DCGM_FI_DEV_SUPPORTED_VGPU_TYPE_IDS represents /
+	// DCGM_FI_DEV_SUPPORTED_VGPU_TYPE_IDS represents Includes Count and currently Supported vGPU types on a device
 	DCGM_FI_DEV_SUPPORTED_VGPU_TYPE_IDS Short = 509
-	// DCGM_FI_DEV_VGPU_TYPE_INFO represents /
+	// DCGM_FI_DEV_VGPU_TYPE_INFO represents Includes Static info of vGPU types supported on a device
 	DCGM_FI_DEV_VGPU_TYPE_INFO Short = 510
-	// DCGM_FI_DEV_VGPU_TYPE_NAME represents /
+	// DCGM_FI_DEV_VGPU_TYPE_NAME represents Includes the name of a vGPU type supported on a device
 	DCGM_FI_DEV_VGPU_TYPE_NAME Short = 511
-	// DCGM_FI_DEV_VGPU_TYPE_CLASS represents /
+	// DCGM_FI_DEV_VGPU_TYPE_CLASS represents Includes the class of a vGPU type supported on a device
 	DCGM_FI_DEV_VGPU_TYPE_CLASS Short = 512
-	// DCGM_FI_DEV_VGPU_TYPE_LICENSE represents /
+	// DCGM_FI_DEV_VGPU_TYPE_LICENSE represents Includes the license info for a vGPU type supported on a device
 	DCGM_FI_DEV_VGPU_TYPE_LICENSE Short = 513
-	// DCGM_FI_FIRST_VGPU_FIELD_ID represents /
+	// DCGM_FI_FIRST_VGPU_FIELD_ID represents Starting field ID of the vGPU instance
 	DCGM_FI_FIRST_VGPU_FIELD_ID Short = 520
-	// DCGM_FI_DEV_VGPU_VM_ID represents /
+	// DCGM_FI_DEV_VGPU_VM_ID represents VM ID of the vGPU instance
 	DCGM_FI_DEV_VGPU_VM_ID Short = 520
-	// DCGM_FI_DEV_VGPU_VM_NAME represents /
+	// DCGM_FI_DEV_VGPU_VM_NAME represents VM name of the vGPU instance
 	DCGM_FI_DEV_VGPU_VM_NAME Short = 521
-	// DCGM_FI_DEV_VGPU_TYPE represents /
+	// DCGM_FI_DEV_VGPU_TYPE represents vGPU type of the vGPU instance
 	DCGM_FI_DEV_VGPU_TYPE Short = 522
-	// DCGM_FI_DEV_VGPU_UUID represents /
+	// DCGM_FI_DEV_VGPU_UUID represents UUID of the vGPU instance
 	DCGM_FI_DEV_VGPU_UUID Short = 523
-	// DCGM_FI_DEV_VGPU_DRIVER_VERSION represents /
+	// DCGM_FI_DEV_VGPU_DRIVER_VERSION represents Driver version of the vGPU instance
 	DCGM_FI_DEV_VGPU_DRIVER_VERSION Short = 524
-	// DCGM_FI_DEV_VGPU_MEMORY_USAGE represents /
+	// DCGM_FI_DEV_VGPU_MEMORY_USAGE represents Memory usage of the vGPU instance
 	DCGM_FI_DEV_VGPU_MEMORY_USAGE Short = 525
-	// DCGM_FI_DEV_VGPU_LICENSE_STATUS represents /
+	// DCGM_FI_DEV_VGPU_LICENSE_STATUS represents 1 = vgpu is licensed
 	DCGM_FI_DEV_VGPU_LICENSE_STATUS Short = 526
-	// DCGM_FI_DEV_VGPU_FRAME_RATE_LIMIT represents /
+	// DCGM_FI_DEV_VGPU_FRAME_RATE_LIMIT represents Frame rate limit of the vGPU instance
 	DCGM_FI_DEV_VGPU_FRAME_RATE_LIMIT Short = 527
-	// DCGM_FI_DEV_VGPU_ENC_STATS represents /
+	// DCGM_FI_DEV_VGPU_ENC_STATS represents Current encoder statistics of the vGPU instance
 	DCGM_FI_DEV_VGPU_ENC_STATS Short = 528
-	// DCGM_FI_DEV_VGPU_ENC_SESSIONS_INFO represents /
+	// DCGM_FI_DEV_VGPU_ENC_SESSIONS_INFO represents Information about all active encoder sessions on the vGPU instance
 	DCGM_FI_DEV_VGPU_ENC_SESSIONS_INFO Short = 529
-	// DCGM_FI_DEV_VGPU_FBC_STATS represents /
+	// DCGM_FI_DEV_VGPU_FBC_STATS represents Statistics of current active frame buffer capture sessions on the vGPU instance
 	DCGM_FI_DEV_VGPU_FBC_STATS Short = 530
-	// DCGM_FI_DEV_VGPU_FBC_SESSIONS_INFO represents /
+	// DCGM_FI_DEV_VGPU_FBC_SESSIONS_INFO represents Information about active frame buffer capture sessions on the vGPU instance
 	DCGM_FI_DEV_VGPU_FBC_SESSIONS_INFO Short = 531
-	// DCGM_FI_DEV_VGPU_INSTANCE_LICENSE_STATE represents /
+	// DCGM_FI_DEV_VGPU_INSTANCE_LICENSE_STATE represents License state information of the vGPU instance
 	DCGM_FI_DEV_VGPU_INSTANCE_LICENSE_STATE Short = 532
-	// DCGM_FI_DEV_VGPU_PCI_ID represents /
+	// DCGM_FI_DEV_VGPU_PCI_ID represents PCI Id of the vGPU instance
 	DCGM_FI_DEV_VGPU_PCI_ID Short = 533
-	// DCGM_FI_DEV_VGPU_VM_GPU_INSTANCE_ID represents /
+	// DCGM_FI_DEV_VGPU_VM_GPU_INSTANCE_ID represents GPU Instance ID for the given vGPU Instance
 	DCGM_FI_DEV_VGPU_VM_GPU_INSTANCE_ID Short = 534
-	// DCGM_FI_LAST_VGPU_FIELD_ID represents /
+	// DCGM_FI_LAST_VGPU_FIELD_ID represents Last field ID of the vGPU instance
 	DCGM_FI_LAST_VGPU_FIELD_ID Short = 570
-	// DCGM_FI_DEV_PLATFORM_INFINIBAND_GUID represents /
+	// DCGM_FI_DEV_PLATFORM_INFINIBAND_GUID represents Infiniband GUID string with format 0xXXXXXXXXXXXXXXXX for the specified GPU.
 	DCGM_FI_DEV_PLATFORM_INFINIBAND_GUID Short = 571
-	// DCGM_FI_DEV_PLATFORM_CHASSIS_SERIAL_NUMBER represents /
+	// DCGM_FI_DEV_PLATFORM_CHASSIS_SERIAL_NUMBER represents Serial number of the chassis containing this GPU
 	DCGM_FI_DEV_PLATFORM_CHASSIS_SERIAL_NUMBER Short = 572
-	// DCGM_FI_DEV_PLATFORM_CHASSIS_SLOT_NUMBER represents /
+	// DCGM_FI_DEV_PLATFORM_CHASSIS_SLOT_NUMBER represents Slot number in the rack containing the GPU (includes switches)
 	DCGM_FI_DEV_PLATFORM_CHASSIS_SLOT_NUMBER Short = 573
-	// DCGM_FI_DEV_PLATFORM_TRAY_INDEX represents /
+	// DCGM_FI_DEV_PLATFORM_TRAY_INDEX represents Tray index within the compute slots in the chassis containing this GPU (does not include switches)
 	DCGM_FI_DEV_PLATFORM_TRAY_INDEX Short = 574
-	// DCGM_FI_DEV_PLATFORM_HOST_ID represents /
+	// DCGM_FI_DEV_PLATFORM_HOST_ID represents Index of the node within the slot containing the GPU
 	DCGM_FI_DEV_PLATFORM_HOST_ID Short = 575
-	// DCGM_FI_DEV_PLATFORM_PEER_TYPE represents /
+	// DCGM_FI_DEV_PLATFORM_PEER_TYPE represents Platform indicated NVLink-peer type (e.g. switch present or not)
 	DCGM_FI_DEV_PLATFORM_PEER_TYPE Short = 576
-	// DCGM_FI_DEV_PLATFORM_MODULE_ID represents /
+	// DCGM_FI_DEV_PLATFORM_MODULE_ID represents ID of the GPU within the node
 	DCGM_FI_DEV_PLATFORM_MODULE_ID Short = 577
-	// DCGM_FI_DEV_NVLINK_PPRM_OPER_RECOVERY represents /
+	// DCGM_FI_DEV_NVLINK_PPRM_OPER_RECOVERY represents PPRM recovery operation status
 	DCGM_FI_DEV_NVLINK_PPRM_OPER_RECOVERY Short = 580
-	// DCGM_FI_DEV_NVLINK_PPCNT_RECOVERY_TIME_SINCE_LAST represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_RECOVERY_TIME_SINCE_LAST represents Time in seconds since last PRM recovery
 	DCGM_FI_DEV_NVLINK_PPCNT_RECOVERY_TIME_SINCE_LAST Short = 581
-	// DCGM_FI_DEV_NVLINK_PPCNT_RECOVERY_TIME_BETWEEN_LAST_TWO represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_RECOVERY_TIME_BETWEEN_LAST_TWO represents Time in milliseconds between last two recoveries
 	DCGM_FI_DEV_NVLINK_PPCNT_RECOVERY_TIME_BETWEEN_LAST_TWO Short = 582
-	// DCGM_FI_DEV_NVLINK_PPCNT_RECOVERY_TOTAL_SUCCESSFUL_EVENTS represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_RECOVERY_TOTAL_SUCCESSFUL_EVENTS represents Total successful recovery events counter
 	DCGM_FI_DEV_NVLINK_PPCNT_RECOVERY_TOTAL_SUCCESSFUL_EVENTS Short = 583
-	// DCGM_FI_DEV_NVLINK_PPCNT_PHYSICAL_SUCCESSFUL_RECOVERY_EVENTS represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_PHYSICAL_SUCCESSFUL_RECOVERY_EVENTS represents Physical layer successful recovery events
 	DCGM_FI_DEV_NVLINK_PPCNT_PHYSICAL_SUCCESSFUL_RECOVERY_EVENTS Short = 584
-	// DCGM_FI_DEV_NVLINK_PPCNT_PHYSICAL_LINK_DOWN_COUNTER represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_PHYSICAL_LINK_DOWN_COUNTER represents Physical layer link down counter
 	DCGM_FI_DEV_NVLINK_PPCNT_PHYSICAL_LINK_DOWN_COUNTER Short = 585
-	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_RCV_CODES represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_RCV_CODES represents PLR received codewords counter
 	DCGM_FI_DEV_NVLINK_PPCNT_PLR_RCV_CODES Short = 586
-	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_RCV_CODE_ERR represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_RCV_CODE_ERR represents PLR received code error counter
 	DCGM_FI_DEV_NVLINK_PPCNT_PLR_RCV_CODE_ERR Short = 587
-	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_RCV_UNCORRECTABLE_CODE represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_RCV_UNCORRECTABLE_CODE represents PLR received uncorrectable codes counter
 	DCGM_FI_DEV_NVLINK_PPCNT_PLR_RCV_UNCORRECTABLE_CODE Short = 588
-	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_XMIT_CODES represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_XMIT_CODES represents PLR transmitted codewords counter
 	DCGM_FI_DEV_NVLINK_PPCNT_PLR_XMIT_CODES Short = 589
-	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_XMIT_RETRY_CODES represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_XMIT_RETRY_CODES represents PLR transmitted retry codes counter
 	DCGM_FI_DEV_NVLINK_PPCNT_PLR_XMIT_RETRY_CODES Short = 590
-	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_XMIT_RETRY_EVENTS represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_XMIT_RETRY_EVENTS represents PLR transmitted retry events counter
 	DCGM_FI_DEV_NVLINK_PPCNT_PLR_XMIT_RETRY_EVENTS Short = 591
-	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_SYNC_EVENTS represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_PLR_SYNC_EVENTS represents PLR sync events counter
 	DCGM_FI_DEV_NVLINK_PPCNT_PLR_SYNC_EVENTS Short = 592
-	// DCGM_FI_INTERNAL_FIELDS_0_START represents /
+	// DCGM_FI_INTERNAL_FIELDS_0_START represents Starting ID for all the internal fields
 	DCGM_FI_INTERNAL_FIELDS_0_START Short = 600
-	// DCGM_FI_INTERNAL_FIELDS_0_END represents /
+	// DCGM_FI_INTERNAL_FIELDS_0_END represents <p>NVSwitch latency bins for port 0</p>
 	DCGM_FI_INTERNAL_FIELDS_0_END Short = 699
-	// DCGM_FI_FIRST_NVSWITCH_FIELD_ID represents /
+	// DCGM_FI_FIRST_NVSWITCH_FIELD_ID represents Starting field ID of the NVSwitch instance
 	DCGM_FI_FIRST_NVSWITCH_FIELD_ID Short = 700
-	// DCGM_FI_DEV_NVSWITCH_VOLTAGE_MVOLT represents /
+	// DCGM_FI_DEV_NVSWITCH_VOLTAGE_MVOLT represents NvSwitch voltage
 	DCGM_FI_DEV_NVSWITCH_VOLTAGE_MVOLT Short = 701
-	// DCGM_FI_DEV_NVSWITCH_CURRENT_IDDQ represents /
+	// DCGM_FI_DEV_NVSWITCH_CURRENT_IDDQ represents NvSwitch Current IDDQ
 	DCGM_FI_DEV_NVSWITCH_CURRENT_IDDQ Short = 702
-	// DCGM_FI_DEV_NVSWITCH_CURRENT_IDDQ_REV represents /
+	// DCGM_FI_DEV_NVSWITCH_CURRENT_IDDQ_REV represents NvSwitch Current IDDQ Rev
 	DCGM_FI_DEV_NVSWITCH_CURRENT_IDDQ_REV Short = 703
-	// DCGM_FI_DEV_NVSWITCH_CURRENT_IDDQ_DVDD represents /
+	// DCGM_FI_DEV_NVSWITCH_CURRENT_IDDQ_DVDD represents NvSwitch Current IDDQ Rev DVDD
 	DCGM_FI_DEV_NVSWITCH_CURRENT_IDDQ_DVDD Short = 704
-	// DCGM_FI_DEV_NVSWITCH_POWER_VDD represents /
+	// DCGM_FI_DEV_NVSWITCH_POWER_VDD represents NvSwitch Power VDD in watts
 	DCGM_FI_DEV_NVSWITCH_POWER_VDD Short = 705
-	// DCGM_FI_DEV_NVSWITCH_POWER_DVDD represents /
+	// DCGM_FI_DEV_NVSWITCH_POWER_DVDD represents NvSwitch Power DVDD in watts
 	DCGM_FI_DEV_NVSWITCH_POWER_DVDD Short = 706
-	// DCGM_FI_DEV_NVSWITCH_POWER_HVDD represents /
+	// DCGM_FI_DEV_NVSWITCH_POWER_HVDD represents NvSwitch Power HVDD in watts
 	DCGM_FI_DEV_NVSWITCH_POWER_HVDD Short = 707
-	// DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_TX represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_TX represents <p>NVSwitch Tx Throughput Counter for ports 0-17</p>
 	DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_TX Short = 780
-	// DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_RX represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_RX represents NVSwitch Rx Throughput Counter for ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_THROUGHPUT_RX Short = 781
-	// DCGM_FI_DEV_NVSWITCH_LINK_FATAL_ERRORS represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_FATAL_ERRORS represents NvSwitch fatal_errors for ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_FATAL_ERRORS Short = 782
-	// DCGM_FI_DEV_NVSWITCH_LINK_NON_FATAL_ERRORS represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_NON_FATAL_ERRORS represents NvSwitch non_fatal_errors for ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_NON_FATAL_ERRORS Short = 783
-	// DCGM_FI_DEV_NVSWITCH_LINK_REPLAY_ERRORS represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_REPLAY_ERRORS represents NvSwitch replay_count_errors for ports  0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_REPLAY_ERRORS Short = 784
-	// DCGM_FI_DEV_NVSWITCH_LINK_RECOVERY_ERRORS represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_RECOVERY_ERRORS represents NvSwitch recovery_count_errors for ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_RECOVERY_ERRORS Short = 785
-	// DCGM_FI_DEV_NVSWITCH_LINK_FLIT_ERRORS represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_FLIT_ERRORS represents NvSwitch filt_err_count_errors for ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_FLIT_ERRORS Short = 786
-	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS represents NvLink lane_crs_err_count_aggregate_errors for ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS Short = 787
-	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS represents NvLink lane ecc_err_count_aggregate_errors for ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS Short = 788
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC0 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC0 represents Nvlink lane latency low lane0 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC0 Short = 789
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC1 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC1 represents Nvlink lane latency low lane1 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC1 Short = 790
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC2 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC2 represents Nvlink lane latency low lane2 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC2 Short = 791
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC3 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC3 represents Nvlink lane latency low lane3 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_LOW_VC3 Short = 792
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC0 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC0 represents Nvlink lane latency medium lane0 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC0 Short = 793
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC1 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC1 represents Nvlink lane latency medium lane1 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC1 Short = 794
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC2 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC2 represents Nvlink lane latency medium lane2 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC2 Short = 795
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC3 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC3 represents Nvlink lane latency medium lane3 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_MEDIUM_VC3 Short = 796
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC0 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC0 represents Nvlink lane latency high lane0 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC0 Short = 797
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC1 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC1 represents Nvlink lane latency high lane1 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC1 Short = 798
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC2 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC2 represents Nvlink lane latency high lane2 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC2 Short = 799
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC3 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC3 represents Nvlink lane latency high lane3 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_HIGH_VC3 Short = 800
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC0 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC0 represents Nvlink lane latency panic lane0 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC0 Short = 801
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC1 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC1 represents Nvlink lane latency panic lane1 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC1 Short = 802
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC2 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC2 represents Nvlink lane latency panic lane2 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC2 Short = 803
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC3 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC3 represents Nvlink lane latency panic lane2 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_PANIC_VC3 Short = 804
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC0 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC0 represents Nvlink lane latency count lane0 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC0 Short = 805
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC1 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC1 represents Nvlink lane latency count lane1 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC1 Short = 806
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC2 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC2 represents Nvlink lane latency count lane2 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC2 Short = 807
-	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC3 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC3 represents Nvlink lane latency count lane3 counter.
 	DCGM_FI_DEV_NVSWITCH_LINK_LATENCY_COUNT_VC3 Short = 808
-	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE0 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE0 represents NvLink lane crc_err_count for lane 0 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE0 Short = 809
-	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE1 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE1 represents NvLink lane crc_err_count for lane 1 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE1 Short = 810
-	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE2 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE2 represents NvLink lane crc_err_count for lane 2 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE2 Short = 811
-	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE3 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE3 represents NvLink lane crc_err_count for lane 3 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE3 Short = 812
-	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE0 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE0 represents NvLink lane ecc_err_count for lane 0 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE0 Short = 813
-	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE1 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE1 represents NvLink lane ecc_err_count for lane 1 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE1 Short = 814
-	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE2 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE2 represents NvLink lane ecc_err_count for lane 2 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE2 Short = 815
-	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE3 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE3 represents NvLink lane ecc_err_count for lane 3 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE3 Short = 816
-	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE4 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE4 represents NvLink lane crc_err_count for lane 4 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE4 Short = 817
-	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE5 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE5 represents NvLink lane crc_err_count for lane 5 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE5 Short = 818
-	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE6 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE6 represents NvLink lane crc_err_count for lane 6 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE6 Short = 819
-	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE7 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE7 represents NvLink lane crc_err_count for lane 7 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_CRC_ERRORS_LANE7 Short = 820
-	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE4 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE4 represents NvLink lane ecc_err_count for lane 4 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE4 Short = 821
-	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE5 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE5 represents NvLink lane ecc_err_count for lane 5 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE5 Short = 822
-	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE6 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE6 represents NvLink lane ecc_err_count for lane 6 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE6 Short = 823
-	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE7 represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE7 represents NvLink lane ecc_err_count for lane 7 on ports 0-17
 	DCGM_FI_DEV_NVSWITCH_LINK_ECC_ERRORS_LANE7 Short = 824
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L0 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L0 represents NV Link TX Throughput for Lane 0
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L0 Short = 825
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L1 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L1 represents NV Link TX Throughput for Lane 1
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L1 Short = 826
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L2 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L2 represents NV Link TX Throughput for Lane 2
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L2 Short = 827
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L3 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L3 represents NV Link TX Throughput for Lane 3
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L3 Short = 828
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L4 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L4 represents NV Link TX Throughput for Lane 4
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L4 Short = 829
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L5 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L5 represents NV Link TX Throughput for Lane 5
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L5 Short = 830
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L6 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L6 represents NV Link TX Throughput for Lane 6
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L6 Short = 831
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L7 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L7 represents NV Link TX Throughput for Lane 7
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L7 Short = 832
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L8 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L8 represents NV Link TX Throughput for Lane 8
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L8 Short = 833
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L9 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L9 represents NV Link TX Throughput for Lane 9
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L9 Short = 834
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L10 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L10 represents NV Link TX Throughput for Lane 10
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L10 Short = 835
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L11 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L11 represents NV Link TX Throughput for Lane 11
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L11 Short = 836
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L12 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L12 represents NV Link TX Throughput for Lane 12
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L12 Short = 837
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L13 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L13 represents NV Link TX Throughput for Lane 13
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L13 Short = 838
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L14 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L14 represents NV Link TX Throughput for Lane 14
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L14 Short = 839
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L15 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L15 represents NV Link TX Throughput for Lane 15
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L15 Short = 840
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L16 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L16 represents NV Link TX Throughput for Lane 16
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L16 Short = 841
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L17 represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L17 represents NV Link TX Throughput for Lane 17
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_L17 Short = 842
-	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_TOTAL represents /
+	// DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_TOTAL represents NV Link Throughput total for all TX Lanes
 	DCGM_FI_DEV_NVLINK_TX_THROUGHPUT_TOTAL Short = 843
-	// DCGM_FI_DEV_NVSWITCH_FATAL_ERRORS represents /
+	// DCGM_FI_DEV_NVSWITCH_FATAL_ERRORS represents Note: value field indicates the specific SXid reported
 	DCGM_FI_DEV_NVSWITCH_FATAL_ERRORS Short = 856
-	// DCGM_FI_DEV_NVSWITCH_NON_FATAL_ERRORS represents /
+	// DCGM_FI_DEV_NVSWITCH_NON_FATAL_ERRORS represents Note: value field indicates the specific SXid reported
 	DCGM_FI_DEV_NVSWITCH_NON_FATAL_ERRORS Short = 857
-	// DCGM_FI_DEV_NVSWITCH_TEMPERATURE_CURRENT represents /
+	// DCGM_FI_DEV_NVSWITCH_TEMPERATURE_CURRENT represents NVSwitch current temperature.
 	DCGM_FI_DEV_NVSWITCH_TEMPERATURE_CURRENT Short = 858
-	// DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SLOWDOWN represents /
+	// DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SLOWDOWN represents NVSwitch limit slowdown temperature.
 	DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SLOWDOWN Short = 859
-	// DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SHUTDOWN represents /
+	// DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SHUTDOWN represents NVSwitch limit shutdown temperature.
 	DCGM_FI_DEV_NVSWITCH_TEMPERATURE_LIMIT_SHUTDOWN Short = 860
-	// DCGM_FI_DEV_NVSWITCH_THROUGHPUT_TX represents /
+	// DCGM_FI_DEV_NVSWITCH_THROUGHPUT_TX represents NVSwitch throughput Tx.
 	DCGM_FI_DEV_NVSWITCH_THROUGHPUT_TX Short = 861
-	// DCGM_FI_DEV_NVSWITCH_THROUGHPUT_RX represents /
+	// DCGM_FI_DEV_NVSWITCH_THROUGHPUT_RX represents NVSwitch throughput Rx.
 	DCGM_FI_DEV_NVSWITCH_THROUGHPUT_RX Short = 862
-	// DCGM_FI_DEV_NVSWITCH_PHYS_ID represents /
+	// DCGM_FI_DEV_NVSWITCH_PHYS_ID represents NVSwitch Physical ID.
 	DCGM_FI_DEV_NVSWITCH_PHYS_ID Short = 863
-	// DCGM_FI_DEV_NVSWITCH_RESET_REQUIRED represents /
+	// DCGM_FI_DEV_NVSWITCH_RESET_REQUIRED represents NVSwitch reset required.
 	DCGM_FI_DEV_NVSWITCH_RESET_REQUIRED Short = 864
-	// DCGM_FI_DEV_NVSWITCH_LINK_ID represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_ID represents NvSwitch NvLink ID
 	DCGM_FI_DEV_NVSWITCH_LINK_ID Short = 865
-	// DCGM_FI_DEV_NVSWITCH_PCIE_DOMAIN represents /
+	// DCGM_FI_DEV_NVSWITCH_PCIE_DOMAIN represents NvSwitch PCIE domain
 	DCGM_FI_DEV_NVSWITCH_PCIE_DOMAIN Short = 866
-	// DCGM_FI_DEV_NVSWITCH_PCIE_BUS represents /
+	// DCGM_FI_DEV_NVSWITCH_PCIE_BUS represents NvSwitch PCIE bus
 	DCGM_FI_DEV_NVSWITCH_PCIE_BUS Short = 867
-	// DCGM_FI_DEV_NVSWITCH_PCIE_DEVICE represents /
+	// DCGM_FI_DEV_NVSWITCH_PCIE_DEVICE represents NvSwitch PCIE device
 	DCGM_FI_DEV_NVSWITCH_PCIE_DEVICE Short = 868
-	// DCGM_FI_DEV_NVSWITCH_PCIE_FUNCTION represents /
+	// DCGM_FI_DEV_NVSWITCH_PCIE_FUNCTION represents NvSwitch PCIE function
 	DCGM_FI_DEV_NVSWITCH_PCIE_FUNCTION Short = 869
-	// DCGM_FI_DEV_NVSWITCH_LINK_STATUS represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_STATUS represents NvLink status.  UNKNOWN:-1 OFF:0 SAFE:1 ACTIVE:2 ERROR:3
 	DCGM_FI_DEV_NVSWITCH_LINK_STATUS Short = 870
-	// DCGM_FI_DEV_NVSWITCH_LINK_TYPE represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_TYPE represents NvLink device type (NSCQ: GPU=1, Switch=2; NVSDM: CA=1, Switch=2, GPU=5)
 	DCGM_FI_DEV_NVSWITCH_LINK_TYPE Short = 871
-	// DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_DOMAIN represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_DOMAIN represents NvLink device pcie domain.
 	DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_DOMAIN Short = 872
-	// DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_BUS represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_BUS represents NvLink device pcie bus.
 	DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_BUS Short = 873
-	// DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_DEVICE represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_DEVICE represents NvLink device pcie device.
 	DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_DEVICE Short = 874
-	// DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_FUNCTION represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_FUNCTION represents NvLink device pcie function.
 	DCGM_FI_DEV_NVSWITCH_LINK_REMOTE_PCIE_FUNCTION Short = 875
-	// DCGM_FI_DEV_NVSWITCH_LINK_DEVICE_LINK_ID represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_DEVICE_LINK_ID represents NvLink device link ID
 	DCGM_FI_DEV_NVSWITCH_LINK_DEVICE_LINK_ID Short = 876
-	// DCGM_FI_DEV_NVSWITCH_LINK_DEVICE_LINK_SID represents /
+	// DCGM_FI_DEV_NVSWITCH_LINK_DEVICE_LINK_SID represents NvLink device SID.
 	DCGM_FI_DEV_NVSWITCH_LINK_DEVICE_LINK_SID Short = 877
-	// DCGM_FI_DEV_NVSWITCH_DEVICE_UUID represents /
+	// DCGM_FI_DEV_NVSWITCH_DEVICE_UUID represents NvLink device switch/link uid.
 	DCGM_FI_DEV_NVSWITCH_DEVICE_UUID Short = 878
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L0 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L0 represents NV Link RX Throughput for Lane 0
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L0 Short = 879
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L1 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L1 represents NV Link RX Throughput for Lane 1
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L1 Short = 880
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L2 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L2 represents NV Link RX Throughput for Lane 2
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L2 Short = 881
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L3 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L3 represents NV Link RX Throughput for Lane 3
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L3 Short = 882
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L4 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L4 represents NV Link RX Throughput for Lane 4
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L4 Short = 883
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L5 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L5 represents NV Link RX Throughput for Lane 5
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L5 Short = 884
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L6 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L6 represents NV Link RX Throughput for Lane 6
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L6 Short = 885
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L7 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L7 represents NV Link RX Throughput for Lane 7
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L7 Short = 886
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L8 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L8 represents NV Link RX Throughput for Lane 8
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L8 Short = 887
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L9 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L9 represents NV Link RX Throughput for Lane 9
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L9 Short = 888
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L10 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L10 represents NV Link RX Throughput for Lane 10
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L10 Short = 889
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L11 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L11 represents NV Link RX Throughput for Lane 11
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L11 Short = 890
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L12 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L12 represents NV Link RX Throughput for Lane 12
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L12 Short = 891
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L13 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L13 represents NV Link RX Throughput for Lane 13
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L13 Short = 892
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L14 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L14 represents NV Link RX Throughput for Lane 14
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L14 Short = 893
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L15 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L15 represents NV Link RX Throughput for Lane 15
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L15 Short = 894
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L16 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L16 represents NV Link RX Throughput for Lane 16
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L16 Short = 895
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L17 represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L17 represents NV Link RX Throughput for Lane 17
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_L17 Short = 896
-	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_TOTAL represents /
+	// DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_TOTAL represents NV Link Throughput total for all RX Lanes
 	DCGM_FI_DEV_NVLINK_RX_THROUGHPUT_TOTAL Short = 897
-	// DCGM_FI_LAST_NVSWITCH_FIELD_ID represents /
+	// DCGM_FI_LAST_NVSWITCH_FIELD_ID represents Last field ID of the NVSwitch instance
 	DCGM_FI_LAST_NVSWITCH_FIELD_ID Short = 899
-	// DCGM_FI_PROF_GR_ENGINE_ACTIVE represents /
+	// DCGM_FI_PROF_GR_ENGINE_ACTIVE represents compute pipe is busy.
 	DCGM_FI_PROF_GR_ENGINE_ACTIVE Short = 1001
-	// DCGM_FI_PROF_SM_ACTIVE represents /
+	// DCGM_FI_PROF_SM_ACTIVE represents (computed from the number of cycles and elapsed cycles)
 	DCGM_FI_PROF_SM_ACTIVE Short = 1002
-	// DCGM_FI_PROF_SM_OCCUPANCY represents /
+	// DCGM_FI_PROF_SM_OCCUPANCY represents maximum number of warps per elapsed cycle)
 	DCGM_FI_PROF_SM_OCCUPANCY Short = 1003
-	// DCGM_FI_PROF_PIPE_TENSOR_ACTIVE represents /
+	// DCGM_FI_PROF_PIPE_TENSOR_ACTIVE represents (off the peak sustained elapsed cycles)
 	DCGM_FI_PROF_PIPE_TENSOR_ACTIVE Short = 1004
-	// DCGM_FI_PROF_DRAM_ACTIVE represents /
+	// DCGM_FI_PROF_DRAM_ACTIVE represents active sending or receiving data.
 	DCGM_FI_PROF_DRAM_ACTIVE Short = 1005
-	// DCGM_FI_PROF_PIPE_FP64_ACTIVE represents /
+	// DCGM_FI_PROF_PIPE_FP64_ACTIVE represents Ratio of cycles the fp64 pipe is active.
 	DCGM_FI_PROF_PIPE_FP64_ACTIVE Short = 1006
-	// DCGM_FI_PROF_PIPE_FP32_ACTIVE represents /
+	// DCGM_FI_PROF_PIPE_FP32_ACTIVE represents Ratio of cycles the fp32 pipe is active.
 	DCGM_FI_PROF_PIPE_FP32_ACTIVE Short = 1007
-	// DCGM_FI_PROF_PIPE_FP16_ACTIVE represents /
+	// DCGM_FI_PROF_PIPE_FP16_ACTIVE represents Ratio of cycles the fp16 pipe is active. This does not include HMMA.
 	DCGM_FI_PROF_PIPE_FP16_ACTIVE Short = 1008
-	// DCGM_FI_PROF_PCIE_TX_BYTES represents /
+	// DCGM_FI_PROF_PCIE_TX_BYTES represents would be reflected in this metric.
 	DCGM_FI_PROF_PCIE_TX_BYTES Short = 1009
-	// DCGM_FI_PROF_PCIE_RX_BYTES represents /
+	// DCGM_FI_PROF_PCIE_RX_BYTES represents would be reflected in this metric.
 	DCGM_FI_PROF_PCIE_RX_BYTES Short = 1010
-	// DCGM_FI_PROF_NVLINK_TX_BYTES represents /
+	// DCGM_FI_PROF_NVLINK_TX_BYTES represents Per-link fields are available below
 	DCGM_FI_PROF_NVLINK_TX_BYTES Short = 1011
-	// DCGM_FI_PROF_NVLINK_RX_BYTES represents /
+	// DCGM_FI_PROF_NVLINK_RX_BYTES represents Per-link fields are available below
 	DCGM_FI_PROF_NVLINK_RX_BYTES Short = 1012
-	// DCGM_FI_PROF_PIPE_TENSOR_IMMA_ACTIVE represents /
+	// DCGM_FI_PROF_PIPE_TENSOR_IMMA_ACTIVE represents The ratio of cycles the tensor (IMMA) pipe is active (off the peak sustained elapsed cycles)
 	DCGM_FI_PROF_PIPE_TENSOR_IMMA_ACTIVE Short = 1013
-	// DCGM_FI_PROF_PIPE_TENSOR_HMMA_ACTIVE represents /
+	// DCGM_FI_PROF_PIPE_TENSOR_HMMA_ACTIVE represents The ratio of cycles the tensor (HMMA) pipe is active (off the peak sustained elapsed cycles)
 	DCGM_FI_PROF_PIPE_TENSOR_HMMA_ACTIVE Short = 1014
-	// DCGM_FI_PROF_PIPE_TENSOR_DFMA_ACTIVE represents /
+	// DCGM_FI_PROF_PIPE_TENSOR_DFMA_ACTIVE represents The ratio of cycles the tensor (DFMA) pipe is active (off the peak sustained elapsed cycles)
 	DCGM_FI_PROF_PIPE_TENSOR_DFMA_ACTIVE Short = 1015
-	// DCGM_FI_PROF_PIPE_INT_ACTIVE represents /
+	// DCGM_FI_PROF_PIPE_INT_ACTIVE represents Ratio of cycles the integer pipe is active.
 	DCGM_FI_PROF_PIPE_INT_ACTIVE Short = 1016
-	// DCGM_FI_PROF_NVDEC0_ACTIVE represents /
+	// DCGM_FI_PROF_NVDEC0_ACTIVE represents Ratio of cycles each of the NVDEC engines are active.
 	DCGM_FI_PROF_NVDEC0_ACTIVE Short = 1017
 	// DCGM_FI_PROF_NVDEC1_ACTIVE
 	DCGM_FI_PROF_NVDEC1_ACTIVE Short = 1018
@@ -961,7 +961,7 @@ const (
 	DCGM_FI_PROF_NVDEC6_ACTIVE Short = 1023
 	// DCGM_FI_PROF_NVDEC7_ACTIVE
 	DCGM_FI_PROF_NVDEC7_ACTIVE Short = 1024
-	// DCGM_FI_PROF_NVJPG0_ACTIVE represents /
+	// DCGM_FI_PROF_NVJPG0_ACTIVE represents Ratio of cycles each of the NVJPG engines are active.
 	DCGM_FI_PROF_NVJPG0_ACTIVE Short = 1025
 	// DCGM_FI_PROF_NVJPG1_ACTIVE
 	DCGM_FI_PROF_NVJPG1_ACTIVE Short = 1026
@@ -977,11 +977,11 @@ const (
 	DCGM_FI_PROF_NVJPG6_ACTIVE Short = 1031
 	// DCGM_FI_PROF_NVJPG7_ACTIVE
 	DCGM_FI_PROF_NVJPG7_ACTIVE Short = 1032
-	// DCGM_FI_PROF_NVOFA0_ACTIVE represents /
+	// DCGM_FI_PROF_NVOFA0_ACTIVE represents Ratio of cycles each of the NVOFA engines are active.
 	DCGM_FI_PROF_NVOFA0_ACTIVE Short = 1033
 	// DCGM_FI_PROF_NVOFA1_ACTIVE
 	DCGM_FI_PROF_NVOFA1_ACTIVE Short = 1034
-	// DCGM_FI_PROF_NVLINK_L0_TX_BYTES represents /
+	// DCGM_FI_PROF_NVLINK_L0_TX_BYTES represents total = DCGM_FI_PROF_NVLINK_L0_TX_BYTES + DCGM_FI_PROF_NVLINK_L0_RX_BYTES
 	DCGM_FI_PROF_NVLINK_L0_TX_BYTES Short = 1040
 	// DCGM_FI_PROF_NVLINK_L0_RX_BYTES
 	DCGM_FI_PROF_NVLINK_L0_RX_BYTES Short = 1041
@@ -1053,221 +1053,221 @@ const (
 	DCGM_FI_PROF_NVLINK_L17_TX_BYTES Short = 1074
 	// DCGM_FI_PROF_NVLINK_L17_RX_BYTES
 	DCGM_FI_PROF_NVLINK_L17_RX_BYTES Short = 1075
-	// DCGM_FI_PROF_C2C_TX_ALL_BYTES represents /
+	// DCGM_FI_PROF_C2C_TX_ALL_BYTES represents The total number of bytes transmitted over the C2C (Chip-to-Chip) interface, including both header and payload data
 	DCGM_FI_PROF_C2C_TX_ALL_BYTES Short = 1076
-	// DCGM_FI_PROF_C2C_TX_DATA_BYTES represents /
+	// DCGM_FI_PROF_C2C_TX_DATA_BYTES represents The number of data-only bytes transmitted over the C2C (Chip-to-Chip) interface
 	DCGM_FI_PROF_C2C_TX_DATA_BYTES Short = 1077
-	// DCGM_FI_PROF_C2C_RX_ALL_BYTES represents /
+	// DCGM_FI_PROF_C2C_RX_ALL_BYTES represents The total number of bytes received over the C2C (Chip-to-Chip) interface, including both header and payload data
 	DCGM_FI_PROF_C2C_RX_ALL_BYTES Short = 1078
-	// DCGM_FI_PROF_C2C_RX_DATA_BYTES represents /
+	// DCGM_FI_PROF_C2C_RX_DATA_BYTES represents The number of data-only bytes received over the C2C (Chip-to-Chip) interface
 	DCGM_FI_PROF_C2C_RX_DATA_BYTES Short = 1079
-	// DCGM_FI_PROF_HOSTMEM_CACHE_HIT represents /
+	// DCGM_FI_PROF_HOSTMEM_CACHE_HIT represents Percentage of requests to Host Memory that were served from cache
 	DCGM_FI_PROF_HOSTMEM_CACHE_HIT Short = 1080
-	// DCGM_FI_PROF_HOSTMEM_CACHE_MISS represents /
+	// DCGM_FI_PROF_HOSTMEM_CACHE_MISS represents Percentage of requests to Host Memory that were cache misses
 	DCGM_FI_PROF_HOSTMEM_CACHE_MISS Short = 1081
-	// DCGM_FI_PROF_PEERMEM_CACHE_HIT represents /
+	// DCGM_FI_PROF_PEERMEM_CACHE_HIT represents Percentage of requests to Peer Memory that were served from cache
 	DCGM_FI_PROF_PEERMEM_CACHE_HIT Short = 1082
-	// DCGM_FI_PROF_PEERMEM_CACHE_MISS represents /
+	// DCGM_FI_PROF_PEERMEM_CACHE_MISS represents Percentage of requests to Peer Memory that were cache misses
 	DCGM_FI_PROF_PEERMEM_CACHE_MISS Short = 1083
-	// DCGM_FI_DEV_CPU_UTIL_TOTAL represents /
+	// DCGM_FI_DEV_CPU_UTIL_TOTAL represents CPU Utilization, total
 	DCGM_FI_DEV_CPU_UTIL_TOTAL Short = 1100
-	// DCGM_FI_DEV_CPU_UTIL_USER represents /
+	// DCGM_FI_DEV_CPU_UTIL_USER represents CPU Utilization, user
 	DCGM_FI_DEV_CPU_UTIL_USER Short = 1101
-	// DCGM_FI_DEV_CPU_UTIL_NICE represents /
+	// DCGM_FI_DEV_CPU_UTIL_NICE represents CPU Utilization, nice
 	DCGM_FI_DEV_CPU_UTIL_NICE Short = 1102
-	// DCGM_FI_DEV_CPU_UTIL_SYS represents /
+	// DCGM_FI_DEV_CPU_UTIL_SYS represents CPU Utilization, system time
 	DCGM_FI_DEV_CPU_UTIL_SYS Short = 1103
-	// DCGM_FI_DEV_CPU_UTIL_IRQ represents /
+	// DCGM_FI_DEV_CPU_UTIL_IRQ represents CPU Utilization, interrupt servicing
 	DCGM_FI_DEV_CPU_UTIL_IRQ Short = 1104
-	// DCGM_FI_DEV_CPU_TEMP_CURRENT represents /
+	// DCGM_FI_DEV_CPU_TEMP_CURRENT represents CPU temperature
 	DCGM_FI_DEV_CPU_TEMP_CURRENT Short = 1110
-	// DCGM_FI_DEV_CPU_TEMP_WARNING represents /
+	// DCGM_FI_DEV_CPU_TEMP_WARNING represents CPU Warning Temperature
 	DCGM_FI_DEV_CPU_TEMP_WARNING Short = 1111
-	// DCGM_FI_DEV_CPU_TEMP_CRITICAL represents /
+	// DCGM_FI_DEV_CPU_TEMP_CRITICAL represents CPU Critical Temperature
 	DCGM_FI_DEV_CPU_TEMP_CRITICAL Short = 1112
-	// DCGM_FI_DEV_CPU_CLOCK_CURRENT represents /
+	// DCGM_FI_DEV_CPU_CLOCK_CURRENT represents CPU instantaneous clock speed
 	DCGM_FI_DEV_CPU_CLOCK_CURRENT Short = 1120
-	// DCGM_FI_DEV_CPU_POWER_UTIL_CURRENT represents /
+	// DCGM_FI_DEV_CPU_POWER_UTIL_CURRENT represents CPU power utilization
 	DCGM_FI_DEV_CPU_POWER_UTIL_CURRENT Short = 1130
-	// DCGM_FI_DEV_CPU_POWER_LIMIT represents /
+	// DCGM_FI_DEV_CPU_POWER_LIMIT represents CPU power limit
 	DCGM_FI_DEV_CPU_POWER_LIMIT Short = 1131
-	// DCGM_FI_DEV_SYSIO_POWER_UTIL_CURRENT represents /
+	// DCGM_FI_DEV_SYSIO_POWER_UTIL_CURRENT represents SoC power utilization
 	DCGM_FI_DEV_SYSIO_POWER_UTIL_CURRENT Short = 1132
-	// DCGM_FI_DEV_MODULE_POWER_UTIL_CURRENT represents /
+	// DCGM_FI_DEV_MODULE_POWER_UTIL_CURRENT represents Module power utilization
 	DCGM_FI_DEV_MODULE_POWER_UTIL_CURRENT Short = 1133
-	// DCGM_FI_DEV_CPU_VENDOR represents /
+	// DCGM_FI_DEV_CPU_VENDOR represents CPU vendor name
 	DCGM_FI_DEV_CPU_VENDOR Short = 1140
-	// DCGM_FI_DEV_CPU_MODEL represents /
+	// DCGM_FI_DEV_CPU_MODEL represents CPU model name
 	DCGM_FI_DEV_CPU_MODEL Short = 1141
-	// DCGM_FI_DEV_NVLINK_COUNT_TX_PACKETS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_TX_PACKETS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_TX_PACKETS Short = 1200
-	// DCGM_FI_DEV_NVLINK_COUNT_TX_BYTES represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_TX_BYTES represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_TX_BYTES Short = 1201
-	// DCGM_FI_DEV_NVLINK_COUNT_RX_PACKETS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_RX_PACKETS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_RX_PACKETS Short = 1202
-	// DCGM_FI_DEV_NVLINK_COUNT_RX_BYTES represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_RX_BYTES represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_RX_BYTES Short = 1203
-	// DCGM_FI_DEV_NVLINK_COUNT_RX_MALFORMED_PACKET_ERRORS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_RX_MALFORMED_PACKET_ERRORS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_RX_MALFORMED_PACKET_ERRORS Short = 1204
-	// DCGM_FI_DEV_NVLINK_COUNT_RX_BUFFER_OVERRUN_ERRORS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_RX_BUFFER_OVERRUN_ERRORS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_RX_BUFFER_OVERRUN_ERRORS Short = 1205
-	// DCGM_FI_DEV_NVLINK_COUNT_RX_ERRORS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_RX_ERRORS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_RX_ERRORS Short = 1206
-	// DCGM_FI_DEV_NVLINK_COUNT_RX_REMOTE_ERRORS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_RX_REMOTE_ERRORS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_RX_REMOTE_ERRORS Short = 1207
-	// DCGM_FI_DEV_NVLINK_COUNT_RX_GENERAL_ERRORS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_RX_GENERAL_ERRORS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_RX_GENERAL_ERRORS Short = 1208
-	// DCGM_FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_LOCAL_LINK_INTEGRITY_ERRORS Short = 1209
-	// DCGM_FI_DEV_NVLINK_COUNT_TX_DISCARDS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_TX_DISCARDS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_TX_DISCARDS Short = 1210
-	// DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_SUCCESSFUL_EVENTS Short = 1211
-	// DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_FAILED_EVENTS Short = 1212
-	// DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_LINK_RECOVERY_EVENTS Short = 1213
-	// DCGM_FI_DEV_NVLINK_COUNT_RX_SYMBOL_ERRORS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_RX_SYMBOL_ERRORS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_RX_SYMBOL_ERRORS Short = 1214
-	// DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER Short = 1215
-	// DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER_FLOAT represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER_FLOAT represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_SYMBOL_BER_FLOAT Short = 1216
-	// DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER Short = 1217
-	// DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER_FLOAT represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER_FLOAT represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_BER_FLOAT Short = 1218
-	// DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_EFFECTIVE_ERRORS Short = 1219
-	// DCGM_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL represents /
+	// DCGM_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL represents NVLink ECC Data Error Counter total for all Links
 	DCGM_FI_DEV_NVLINK_ECC_DATA_ERROR_COUNT_TOTAL Short = 1220
-	// DCGM_FI_DEV_FIRST_CONNECTX_FIELD_ID represents /
+	// DCGM_FI_DEV_FIRST_CONNECTX_FIELD_ID represents First field id of ConnectX
 	DCGM_FI_DEV_FIRST_CONNECTX_FIELD_ID Short = 1300
-	// DCGM_FI_DEV_CONNECTX_HEALTH represents /
+	// DCGM_FI_DEV_CONNECTX_HEALTH represents Health state of ConnectX
 	DCGM_FI_DEV_CONNECTX_HEALTH Short = 1300
-	// DCGM_FI_DEV_CONNECTX_ACTIVE_PCIE_LINK_WIDTH represents /
+	// DCGM_FI_DEV_CONNECTX_ACTIVE_PCIE_LINK_WIDTH represents Active PCIe link width
 	DCGM_FI_DEV_CONNECTX_ACTIVE_PCIE_LINK_WIDTH Short = 1301
-	// DCGM_FI_DEV_CONNECTX_ACTIVE_PCIE_LINK_SPEED represents /
+	// DCGM_FI_DEV_CONNECTX_ACTIVE_PCIE_LINK_SPEED represents Active PCIe link speed
 	DCGM_FI_DEV_CONNECTX_ACTIVE_PCIE_LINK_SPEED Short = 1302
-	// DCGM_FI_DEV_CONNECTX_EXPECT_PCIE_LINK_WIDTH represents /
+	// DCGM_FI_DEV_CONNECTX_EXPECT_PCIE_LINK_WIDTH represents Expect PCIe link width
 	DCGM_FI_DEV_CONNECTX_EXPECT_PCIE_LINK_WIDTH Short = 1303
-	// DCGM_FI_DEV_CONNECTX_EXPECT_PCIE_LINK_SPEED represents /
+	// DCGM_FI_DEV_CONNECTX_EXPECT_PCIE_LINK_SPEED represents Expect PCIe link speed
 	DCGM_FI_DEV_CONNECTX_EXPECT_PCIE_LINK_SPEED Short = 1304
-	// DCGM_FI_DEV_CONNECTX_CORRECTABLE_ERR_STATUS represents /
+	// DCGM_FI_DEV_CONNECTX_CORRECTABLE_ERR_STATUS represents Correctable error status
 	DCGM_FI_DEV_CONNECTX_CORRECTABLE_ERR_STATUS Short = 1305
-	// DCGM_FI_DEV_CONNECTX_CORRECTABLE_ERR_MASK represents /
+	// DCGM_FI_DEV_CONNECTX_CORRECTABLE_ERR_MASK represents Correctable error mask
 	DCGM_FI_DEV_CONNECTX_CORRECTABLE_ERR_MASK Short = 1306
-	// DCGM_FI_DEV_CONNECTX_UNCORRECTABLE_ERR_STATUS represents /
+	// DCGM_FI_DEV_CONNECTX_UNCORRECTABLE_ERR_STATUS represents Uncorrectable error status
 	DCGM_FI_DEV_CONNECTX_UNCORRECTABLE_ERR_STATUS Short = 1307
-	// DCGM_FI_DEV_CONNECTX_UNCORRECTABLE_ERR_MASK represents /
+	// DCGM_FI_DEV_CONNECTX_UNCORRECTABLE_ERR_MASK represents Uncorrectable error mask
 	DCGM_FI_DEV_CONNECTX_UNCORRECTABLE_ERR_MASK Short = 1308
-	// DCGM_FI_DEV_CONNECTX_UNCORRECTABLE_ERR_SEVERITY represents /
+	// DCGM_FI_DEV_CONNECTX_UNCORRECTABLE_ERR_SEVERITY represents Uncorrectable error severity
 	DCGM_FI_DEV_CONNECTX_UNCORRECTABLE_ERR_SEVERITY Short = 1309
-	// DCGM_FI_DEV_CONNECTX_DEVICE_TEMPERATURE represents /
+	// DCGM_FI_DEV_CONNECTX_DEVICE_TEMPERATURE represents Device temperature
 	DCGM_FI_DEV_CONNECTX_DEVICE_TEMPERATURE Short = 1310
-	// DCGM_FI_DEV_LAST_CONNECTX_FIELD_ID represents /
+	// DCGM_FI_DEV_LAST_CONNECTX_FIELD_ID represents The last field id of ConnectX
 	DCGM_FI_DEV_LAST_CONNECTX_FIELD_ID Short = 1399
-	// DCGM_FI_DEV_C2C_LINK_ERROR_INTR represents /
+	// DCGM_FI_DEV_C2C_LINK_ERROR_INTR represents C2C Link CRC Error Counter
 	DCGM_FI_DEV_C2C_LINK_ERROR_INTR Short = 1400
-	// DCGM_FI_DEV_C2C_LINK_ERROR_REPLAY represents /
+	// DCGM_FI_DEV_C2C_LINK_ERROR_REPLAY represents C2C Link Replay Error Counter
 	DCGM_FI_DEV_C2C_LINK_ERROR_REPLAY Short = 1401
-	// DCGM_FI_DEV_C2C_LINK_ERROR_REPLAY_B2B represents /
+	// DCGM_FI_DEV_C2C_LINK_ERROR_REPLAY_B2B represents C2C Link Back to Back Replay Error Counter
 	DCGM_FI_DEV_C2C_LINK_ERROR_REPLAY_B2B Short = 1402
-	// DCGM_FI_DEV_C2C_LINK_POWER_STATE represents /
+	// DCGM_FI_DEV_C2C_LINK_POWER_STATE represents C2C Link Power state. See NVML_C2C_POWER_STATE_*
 	DCGM_FI_DEV_C2C_LINK_POWER_STATE Short = 1403
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_0 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_0 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_0 Short = 1404
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_1 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_1 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_1 Short = 1405
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_2 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_2 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_2 Short = 1406
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_3 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_3 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_3 Short = 1407
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_4 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_4 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_4 Short = 1408
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_5 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_5 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_5 Short = 1409
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_6 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_6 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_6 Short = 1410
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_7 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_7 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_7 Short = 1411
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_8 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_8 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_8 Short = 1412
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_9 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_9 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_9 Short = 1413
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_10 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_10 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_10 Short = 1414
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_11 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_11 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_11 Short = 1415
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_12 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_12 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_12 Short = 1416
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_13 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_13 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_13 Short = 1417
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_14 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_14 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_14 Short = 1418
-	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_15 represents /
+	// DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_15 represents Note: NVLink5+ only. Returns aggregate value across all links. Not supported on NVLink4 and earlier.
 	DCGM_FI_DEV_NVLINK_COUNT_FEC_HISTORY_15 Short = 1419
-	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_SW_POWER_CAP_NS represents /
+	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_SW_POWER_CAP_NS represents Throttling to not exceed currently set power limits in ns
 	DCGM_FI_DEV_CLOCKS_EVENT_REASON_SW_POWER_CAP_NS Short = 1420
-	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_SYNC_BOOST_NS represents /
+	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_SYNC_BOOST_NS represents Boost Group in ns
 	DCGM_FI_DEV_CLOCKS_EVENT_REASON_SYNC_BOOST_NS Short = 1421
-	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_SW_THERM_SLOWDOWN_NS represents /
+	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_SW_THERM_SLOWDOWN_NS represents (Memory Temp < Memory Max Operating Temp)) in ns
 	DCGM_FI_DEV_CLOCKS_EVENT_REASON_SW_THERM_SLOWDOWN_NS Short = 1422
-	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_HW_THERM_SLOWDOWN_NS represents /
+	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_HW_THERM_SLOWDOWN_NS represents clocks by a factor of 2 or more) in ns
 	DCGM_FI_DEV_CLOCKS_EVENT_REASON_HW_THERM_SLOWDOWN_NS Short = 1423
-	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_HW_POWER_BRAKE_SLOWDOWN_NS represents /
+	// DCGM_FI_DEV_CLOCKS_EVENT_REASON_HW_POWER_BRAKE_SLOWDOWN_NS represents (reducing core clocks by a factor of 2 or more) in ns
 	DCGM_FI_DEV_CLOCKS_EVENT_REASON_HW_POWER_BRAKE_SLOWDOWN_NS Short = 1424
-	// DCGM_FI_DEV_PWR_SMOOTHING_ENABLED represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_ENABLED represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_ENABLED Short = 1425
-	// DCGM_FI_DEV_PWR_SMOOTHING_PRIV_LVL represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_PRIV_LVL represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_PRIV_LVL Short = 1426
-	// DCGM_FI_DEV_PWR_SMOOTHING_IMM_RAMP_DOWN_ENABLED represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_IMM_RAMP_DOWN_ENABLED represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_IMM_RAMP_DOWN_ENABLED Short = 1427
-	// DCGM_FI_DEV_PWR_SMOOTHING_APPLIED_TMP_CEIL represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_APPLIED_TMP_CEIL represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_APPLIED_TMP_CEIL Short = 1428
-	// DCGM_FI_DEV_PWR_SMOOTHING_APPLIED_TMP_FLOOR represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_APPLIED_TMP_FLOOR represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_APPLIED_TMP_FLOOR Short = 1429
-	// DCGM_FI_DEV_PWR_SMOOTHING_MAX_PERCENT_TMP_FLOOR_SETTING represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_MAX_PERCENT_TMP_FLOOR_SETTING represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_MAX_PERCENT_TMP_FLOOR_SETTING Short = 1430
-	// DCGM_FI_DEV_PWR_SMOOTHING_MIN_PERCENT_TMP_FLOOR_SETTING represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_MIN_PERCENT_TMP_FLOOR_SETTING represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_MIN_PERCENT_TMP_FLOOR_SETTING Short = 1431
-	// DCGM_FI_DEV_PWR_SMOOTHING_HW_CIRCUITRY_PERCENT_LIFETIME_REMAINING represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_HW_CIRCUITRY_PERCENT_LIFETIME_REMAINING represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_HW_CIRCUITRY_PERCENT_LIFETIME_REMAINING Short = 1432
-	// DCGM_FI_DEV_PWR_SMOOTHING_MAX_NUM_PRESET_PROFILES represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_MAX_NUM_PRESET_PROFILES represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_MAX_NUM_PRESET_PROFILES Short = 1433
-	// DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_PERCENT_TMP_FLOOR represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_PERCENT_TMP_FLOOR represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_PERCENT_TMP_FLOOR Short = 1434
-	// DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_RAMP_UP_RATE represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_RAMP_UP_RATE represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_RAMP_UP_RATE Short = 1435
-	// DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_RAMP_DOWN_RATE represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_RAMP_DOWN_RATE represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_RAMP_DOWN_RATE Short = 1436
-	// DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_RAMP_DOWN_HYST_VAL represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_RAMP_DOWN_HYST_VAL represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_PROFILE_RAMP_DOWN_HYST_VAL Short = 1437
-	// DCGM_FI_DEV_PWR_SMOOTHING_ACTIVE_PRESET_PROFILE represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_ACTIVE_PRESET_PROFILE represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_ACTIVE_PRESET_PROFILE Short = 1438
-	// DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_PERCENT_TMP_FLOOR represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_PERCENT_TMP_FLOOR represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_PERCENT_TMP_FLOOR Short = 1439
-	// DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_UP_RATE represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_UP_RATE represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_UP_RATE Short = 1440
-	// DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_RATE represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_RATE represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_RATE Short = 1441
-	// DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL represents /
+	// DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL represents either level 1 or level 2 (e.g. via Redfish API)
 	DCGM_FI_DEV_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL Short = 1442
-	// DCGM_FI_DEV_PCIE_COUNT_CORRECTABLE_ERRORS represents /
+	// DCGM_FI_DEV_PCIE_COUNT_CORRECTABLE_ERRORS represents PCIe Correctable Errors Counter
 	DCGM_FI_DEV_PCIE_COUNT_CORRECTABLE_ERRORS Short = 1501
-	// DCGM_FI_IMEX_DOMAIN_STATUS represents /
+	// DCGM_FI_IMEX_DOMAIN_STATUS represents Retrieved from nvidia-imex-ctl -N -j command
 	DCGM_FI_IMEX_DOMAIN_STATUS Short = 1502
-	// DCGM_FI_IMEX_DAEMON_STATUS represents /
+	// DCGM_FI_IMEX_DAEMON_STATUS represents WAITING_FOR_RECOVERY=3, INIT_GPU=4, READY=5, SHUTTING_DOWN=6, UNAVAILABLE=7
 	DCGM_FI_IMEX_DAEMON_STATUS Short = 1503
-	// DCGM_FI_DEV_MEMORY_UNREPAIRABLE_FLAG represents /
+	// DCGM_FI_DEV_MEMORY_UNREPAIRABLE_FLAG represents 1=yes, 0=no
 	DCGM_FI_DEV_MEMORY_UNREPAIRABLE_FLAG Short = 1507
-	// DCGM_FI_DEV_NVLINK_GET_STATE represents /
+	// DCGM_FI_DEV_NVLINK_GET_STATE represents Use DCGM_FE_LINK entity group when accessing this field.
 	DCGM_FI_DEV_NVLINK_GET_STATE Short = 1508
-	// DCGM_FI_DEV_NVLINK_PPCNT_IBPC_PORT_XMIT_WAIT represents /
+	// DCGM_FI_DEV_NVLINK_PPCNT_IBPC_PORT_XMIT_WAIT represents Use DCGM_FE_LINK entity group when accessing this field.
 	DCGM_FI_DEV_NVLINK_PPCNT_IBPC_PORT_XMIT_WAIT Short = 1509
-	// DCGM_FI_DEV_GET_GPU_RECOVERY_ACTION represents /
+	// DCGM_FI_DEV_GET_GPU_RECOVERY_ACTION represents GPU Recovery Action (see nvmlDeviceGpuRecoveryAction_t for return values)
 	DCGM_FI_DEV_GET_GPU_RECOVERY_ACTION Short = 1523
-	// DCGM_FI_DEV_NVSWITCH_FIRMWARE_VERSION represents /
+	// DCGM_FI_DEV_NVSWITCH_FIRMWARE_VERSION represents NVSwitch firmware version string
 	DCGM_FI_DEV_NVSWITCH_FIRMWARE_VERSION Short = 1524
 )
 
@@ -1903,6 +1903,64 @@ var dcgmFields = map[string]Short{
 
 // legacyDCGMFields maps legacy field names to their IDs
 var legacyDCGMFields = map[string]Short{
+	"DCGM_FI_DEV_CLOCK_THROTTLE_REASONS":     112,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L0":        440,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L1":        441,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L10":       479,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L11":       480,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L12":       446,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L13":       447,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L14":       448,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L15":       494,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L16":       495,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L17":       496,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L2":        442,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L3":        443,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L4":        444,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L5":        445,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L6":        475,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L7":        476,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L8":        477,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_L9":        478,
+	"DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL":     449,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L0":     879,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L1":     880,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L10":    889,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L11":    890,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L12":    891,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L13":    892,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L14":    893,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L15":    894,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L16":    895,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L17":    896,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L2":     881,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L3":     882,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L4":     883,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L5":     884,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L6":     885,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L7":     886,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L8":     887,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_L9":     888,
+	"DCGM_FI_DEV_NVLINK_RX_BANDWIDTH_TOTAL":  897,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L0":     825,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L1":     826,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L10":    835,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L11":    836,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L12":    837,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L13":    838,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L14":    839,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L15":    840,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L16":    841,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L17":    842,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L2":     827,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L3":     828,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L4":     829,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L5":     830,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L6":     831,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L7":     832,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L8":     833,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_L9":     834,
+	"DCGM_FI_DEV_NVLINK_TX_BANDWIDTH_TOTAL":  843,
 	"dcgm_board_limit_violation":             243,
 	"dcgm_dec_utilization":                   207,
 	"dcgm_ecc_dbe_aggregate_total":           313,


### PR DESCRIPTION
## Summary

`dcgm_fields.h` documents renamed field names two ways: inside `#ifdef DCGM_DEPRECATED ... #endif` blocks, and via `Deprecated: Use X` comments attached to a `#define OLD NEW` line. `gen-fields` only recognised integer `#define NAME <int>` lines, so these alias shapes were silently dropped from `legacyDCGMFields` — `GetFieldID` returned not-found for names that DCGM itself still accepts at the preprocessor layer.

## Commits

1. `feat(gen-fields): resolve deprecated #define aliases into legacyDCGMFields` — generator logic, `extractLegacyFields` tightening, Makefile `gofmt` step, and regenerated output.
2. `docs(gen-fields): document deprecated-alias resolution and fix output example` — README update plus a pre-existing output-example correction.
3. `test(gen-fields): rename misleading tests, close coverage gaps` — two renames, a strengthened `/** @} */`-recovery test, and additional permutation coverage.

## Changes

- Track `/** ... */` comment blocks properly in `parseHeader`. The previous "any line with `*` is comment-content" heuristic let the closing `*/` match `commentPattern` as ` * /` and overwrite `lastComment` with `/`, which is why `const_fields.go` had 544 lines of `// X represents /`. Fixing the tracking is a prerequisite to the deprecated-alias heuristic below and clears the pre-existing rendering artefacts as a side effect.
- Collect `#define DCGM_FI_OLD DCGM_FI_NEW` lines and record them when the alias is inside an `#ifdef DCGM_DEPRECATED` block OR its preceding comment contains case-insensitive `deprecated:`. Range sentinels like `DCGM_FI_PROF_NVLINK_THROUGHPUT_FIRST` stay silently rejected.
- `resolveAliases` returns an error if any deprecated alias's target is not a known field, so header churn fails generation loudly rather than shipping a legacy map missing names that were previously exposed.
- Tighten `extractLegacyFields`: lowercase curated 1.x names preserved, `DCGM_FI_*` entries re-derived each run (stale aliases removed from the header disappear naturally), any other uppercase entry is a hard error.
- Add `gofmt -w pkg/dcgm/const_fields.go` to the `generate` target so regenerated output stays canonically formatted and `make check-generate` stays stable.
- Update `cmd/gen-fields/README.md` to describe the new behavior; fix a pre-existing bug in the output example that showed curated lowercase names inside `dcgmFields` instead of `legacyDCGMFields`.

## Tests

- `cmd/gen-fields/main_test.go`: 19 tests covering the parser-scope matrix, the `*/`-corruption fix, `/** @} */` single-line recovery (every assertion on state strictly AFTER the marker), `Deprecated:`-comment-on-numeric-define leak prevention, nested `#ifdef`, case-insensitive marker, word-without-colon rejection, blank-line-between-comment-and-define, `resolveAliases` missing-target, `extractLegacyFields` provenance rules (lowercase preserved, DCGM_FI_ dropped, other uppercase errors, file-not-found is `os.IsNotExist`, mixed-provenance), and a full-pipeline `TestGenerateOutput_FullPipeline` that drives `parseHeader` → `resolveAliases` → merge → `generateOutput` and asserts on the emitted file.
- `pkg/dcgm/alias_resolution_test.go`: 6 pure public-API regressions. Asserts `GetFieldID(alias) == GetFieldID(canonical)` (semantic equivalence, not literal IDs), `IsLegacyField` / `IsCurrentField` semantics, `GetFieldIDOrPanic` on an alias, and that non-deprecated aliases stay unresolvable. No `setupTest(t)`, no DCGM runtime required.

## Diff shape

Regenerated `pkg/dcgm/const_fields.go` gains 58 `DCGM_FI_*` entries in `legacyDCGMFields` (57 from the `#ifdef DCGM_DEPRECATED` block plus `DCGM_FI_DEV_CLOCK_THROTTLE_REASONS` from the `Deprecated:` comment) and clears the 544 `// X represents /` comment artefacts. The diff is large but mechanical — every changed line is either a new alias entry, a fixed comment, or a formatting fix from the added `gofmt` step.

## Verification

- `go test ./cmd/gen-fields/ ./pkg/dcgm/` — no DCGM runtime required for either package.
- `make check-generate` is stable; `make generate` is idempotent on the committed state.
- Exhaustive cross-check: every one of the 58 `DCGM_FI_*` entries in `legacyDCGMFields` maps to the canonical target's ID in the header.
- End-to-end: a downstream Go consumer's integration suite that previously failed because `GetFieldID("DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL")` returned not-found now passes.