### PR TITLE
fix(policy): Fix DCGM policy listener fanout and preserve policy thresholds

### DIFF
--- a/pkg/dcgm/api.go
+++ b/pkg/dcgm/api.go
@@ -130,11 +130,15 @@ func HealthCheckByGpuId(gpuID uint) (DeviceHealth, error) {
 }
 
 // ListenForPolicyViolations sets up monitoring for the specified policy conditions on all GPUs.
-// Returns a channel that receives policy violations and any error encountered.
+// Returns a channel that receives policy violations and any error encountered. Delivery is
+// best-effort: callers must drain the returned channel promptly, or matching violations may be
+// dropped for that caller. Use PolicyViolationDropCount to observe local drops.
 //
 // Important: The context MUST be cancelled when monitoring is no longer needed to properly
 // clean up resources and prevent goroutine leaks. When the context is cancelled, the returned
-// channel will be closed and all resources will be automatically cleaned up.
+// channel will be closed after local cleanup completes. Concurrent listeners are independent
+// subscribers; each active listener receives matching violations instead of sharing one queue.
+// Empty condition lists and unknown policy conditions return an error before registering with DCGM.
 //
 // Example:
 //
@@ -155,10 +159,13 @@ func ListenForPolicyViolations(ctx context.Context, typ ...policyCondition) (<-c
 }
 
 // ListenForPolicyViolationsForGroup sets up policy monitoring for the specified GPU group.
-// Returns a channel that receives policy violations and any error encountered.
+// Returns a best-effort channel that receives policy violations and any error encountered.
 //
 // Important: The context MUST be cancelled when monitoring is no longer needed to properly
-// clean up resources and prevent goroutine leaks. See ListenForPolicyViolations for usage example.
+// clean up resources and prevent goroutine leaks. Canceling one listener only closes that
+// listener's channel; surviving listeners remain registered until their contexts are canceled.
+// Empty condition lists and unknown policy conditions return an error before registering with DCGM.
+// See ListenForPolicyViolations for usage example.
 func ListenForPolicyViolationsForGroup(ctx context.Context, group GroupHandle, typ ...policyCondition) (<-chan PolicyViolation, error) {
 	return registerPolicy(ctx, group, typ...)
 }
@@ -209,7 +216,17 @@ func ClearPolicyForGroup(group GroupHandle) error {
 	return clearPolicyForGroup(group)
 }
 
-// WatchPolicyViolationsForGroup registers to receive violation notifications for a specific GPU group
+// WatchPolicyViolationsForGroup registers to receive violation notifications for a specific GPU group.
+// Unlike ListenForPolicyViolationsForGroup, it does not set policy thresholds first. Delivery is
+// best-effort, the context must be canceled to release resources, and canceling one watcher does
+// not stop surviving watchers. Empty condition lists and unknown policy conditions return an error
+// before registering with DCGM.
 func WatchPolicyViolationsForGroup(ctx context.Context, group GroupHandle, typ ...PolicyCondition) (<-chan PolicyViolation, error) {
 	return registerPolicyOnly(ctx, group, typ...)
+}
+
+// PolicyViolationDropCount returns the number of local policy violations dropped because
+// listener channels were full. The counter is process-wide and monotonically increasing.
+func PolicyViolationDropCount() uint64 {
+	return policyCallbacks.dropped()
 }

--- a/pkg/dcgm/callback.c
+++ b/pkg/dcgm/callback.c
@@ -1,4 +1,8 @@
-int violationNotify(void* p) {
-    int ViolationRegistration(void*);
-    return ViolationRegistration(p);
+#include <stdint.h>
+
+#include "dcgm_structs.h"
+
+int violationNotify(dcgmPolicyCallbackResponse_t *response, uint64_t userData) {
+    int ViolationRegistration(dcgmPolicyCallbackResponse_t *, uint64_t);
+    return ViolationRegistration(response, userData);
 }

--- a/pkg/dcgm/policy.go
+++ b/pkg/dcgm/policy.go
@@ -1,20 +1,23 @@
 package dcgm
 
 /*
+#include <stdint.h>
 #include "dcgm_agent.h"
 #include "dcgm_structs.h"
 
 // wrapper for go callback function
-extern int violationNotify(void* p);
+extern int violationNotify(dcgmPolicyCallbackResponse_t *response, uint64_t userData);
 */
 import "C"
 
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 )
@@ -186,123 +189,482 @@ type XidPolicyCondition struct {
 }
 
 var (
-	policyMapOnce    sync.Once
-	policyCleanupMux sync.Mutex
-
-	// callbacks maps PolicyViolation channels with policy
-	// captures C callback() value for each violation condition
-	callbacks map[string]chan PolicyViolation
-
-	// paramMap maps C.dcgmPolicy_t.parms index and limits
-	// to be used in setPolicy() for setting user selected policies
-	paramMap map[policyIndex]policyConditionParam
-
-	// activeListeners tracks the number of active policy listeners
-	// to prevent premature cleanup of global callback channels
-	activeListeners int
-
-	// policyChannelsInitialized tracks whether policy channels have been initialized
-	// Protected by policyCleanupMux
-	policyChannelsInitialized bool
+	policyCallbacks = newPolicyDispatcher()
 )
 
-func makePolicyChannels() {
-	policyCleanupMux.Lock()
-	defer policyCleanupMux.Unlock()
+type translatedPolicyConditions struct {
+	condition C.dcgmPolicyCondition_t
+}
 
-	if !policyChannelsInitialized {
-		callbacks = make(map[string]chan PolicyViolation)
-		callbacks["dbe"] = make(chan PolicyViolation, 1)
-		callbacks["pcie"] = make(chan PolicyViolation, 1)
-		callbacks["maxrtpg"] = make(chan PolicyViolation, 1)
-		callbacks["thermal"] = make(chan PolicyViolation, 1)
-		callbacks["power"] = make(chan PolicyViolation, 1)
-		callbacks["nvlink"] = make(chan PolicyViolation, 1)
-		callbacks["xid"] = make(chan PolicyViolation, 1)
-		policyChannelsInitialized = true
+type policySubscription struct {
+	id         uint64
+	groupKey   uintptr
+	conditions C.dcgmPolicyCondition_t
+	ch         chan PolicyViolation
+}
+
+type policyRegistration struct {
+	id         uint64
+	group      GroupHandle
+	groupKey   uintptr
+	conditions C.dcgmPolicyCondition_t
+}
+
+type policyUnregister struct {
+	group     GroupHandle
+	condition C.dcgmPolicyCondition_t
+}
+
+type policyDispatcher struct {
+	registerMu sync.Mutex
+	mu         sync.Mutex
+	nextID     uint64
+
+	subscriptions     map[uint64]*policySubscription
+	registrations     map[uint64]policyRegistration
+	registeredByGroup map[uintptr]C.dcgmPolicyCondition_t
+
+	drops atomic.Uint64
+}
+
+// newPolicyDispatcher initializes the Go-side policy callback registry.
+func newPolicyDispatcher() *policyDispatcher {
+	return &policyDispatcher{
+		subscriptions:     make(map[uint64]*policySubscription),
+		registrations:     make(map[uint64]policyRegistration),
+		registeredByGroup: make(map[uintptr]C.dcgmPolicyCondition_t),
 	}
 }
 
-// cleanupPolicyChannels cleans up global policy callback channels.
-// This is called internally when there are no more active listeners.
-func cleanupPolicyChannels() {
-	policyCleanupMux.Lock()
-	defer policyCleanupMux.Unlock()
+// nextLocked returns the next non-zero dispatcher ID; d.mu must be held.
+func (d *policyDispatcher) nextLocked() uint64 {
+	d.nextID++
+	if d.nextID == 0 {
+		d.nextID++
+	}
+	return d.nextID
+}
 
-	if activeListeners > 0 {
+// addSubscription records a listener and returns any missing DCGM registration.
+func (d *policyDispatcher) addSubscription(
+	group GroupHandle,
+	conditions C.dcgmPolicyCondition_t,
+	buffer int,
+) (uint64, chan PolicyViolation, *policyRegistration) {
+	if buffer < 1 {
+		buffer = 1
+	}
+
+	groupKey := group.GetHandle()
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	subID := d.nextLocked()
+	ch := make(chan PolicyViolation, buffer)
+	d.subscriptions[subID] = &policySubscription{
+		id:         subID,
+		groupKey:   groupKey,
+		conditions: conditions,
+		ch:         ch,
+	}
+
+	missing := conditions &^ d.registeredByGroup[groupKey]
+	if missing == 0 {
+		return subID, ch, nil
+	}
+
+	regID := d.nextLocked()
+	registration := policyRegistration{
+		id:         regID,
+		group:      group,
+		groupKey:   groupKey,
+		conditions: missing,
+	}
+	d.registrations[regID] = registration
+	d.registeredByGroup[groupKey] |= missing
+
+	return subID, ch, &registration
+}
+
+// removeSubscription removes one listener and returns final-subscriber unregister work.
+func (d *policyDispatcher) removeSubscription(subID uint64) (chan PolicyViolation, []policyUnregister) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	sub, exists := d.subscriptions[subID]
+	if !exists {
+		return nil, nil
+	}
+	delete(d.subscriptions, subID)
+
+	if len(d.subscriptions) > 0 {
+		// Per-group teardown is intentionally deferred until the final local subscriber exits.
+		// If one group's subscribers leave while another group remains active, callbacks for
+		// the first group can still enter Go, but deliver drops them because no subscription
+		// matches that group. This keeps lifecycle ownership simple until per-group refcounts
+		// are needed.
+		return sub.ch, nil
+	}
+
+	unregisterByGroup := make(map[uintptr]policyUnregister)
+	for _, registration := range d.registrations {
+		entry := unregisterByGroup[registration.groupKey]
+		if entry.condition == 0 {
+			entry.group = registration.group
+		}
+		entry.condition |= registration.conditions
+		unregisterByGroup[registration.groupKey] = entry
+	}
+
+	unregisters := make([]policyUnregister, 0, len(unregisterByGroup))
+	for _, entry := range unregisterByGroup {
+		unregisters = append(unregisters, entry)
+	}
+
+	return sub.ch, unregisters
+}
+
+// clearRegistrations removes bookkeeping for DCGM registrations that are gone.
+func (d *policyDispatcher) clearRegistrations(unregisters []policyUnregister) {
+	if len(unregisters) == 0 {
 		return
 	}
 
-	if callbacks != nil {
-		// Drain and close all channels
-		for key, ch := range callbacks {
-			select {
-			case <-ch:
-				// Drain any pending values
-			default:
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for _, unregister := range unregisters {
+		groupKey := unregister.group.GetHandle()
+		for regID, registration := range d.registrations {
+			if registration.groupKey != groupKey {
+				continue
 			}
-			close(ch)
-			delete(callbacks, key)
+
+			remaining := registration.conditions &^ unregister.condition
+			if remaining == 0 {
+				delete(d.registrations, regID)
+				continue
+			}
+
+			registration.conditions = remaining
+			d.registrations[regID] = registration
 		}
-		callbacks = nil
-		// Reset the initialization flag to allow re-initialization
-		policyChannelsInitialized = false
+
+		remaining := d.registeredByGroup[groupKey] &^ unregister.condition
+		if remaining == 0 {
+			delete(d.registeredByGroup, groupKey)
+		} else {
+			d.registeredByGroup[groupKey] = remaining
+		}
 	}
 }
 
-func makePolicyParmsMap() {
-	const (
-		policyFieldTypeBool    = 0
-		policyFieldTypeLong    = 1
-		policyBoolValue        = 1
-		policyMaxRtPgThreshold = 10
-		policyThermalThreshold = 100
-		policyPowerThreshold   = 250
-	)
-
-	policyMapOnce.Do(func() {
-		paramMap = make(map[policyIndex]policyConditionParam)
-		paramMap[dbePolicyIndex] = policyConditionParam{
-			typ:   policyFieldTypeBool,
-			value: policyBoolValue,
+// rollbackSubscription undoes local state after DCGM registration fails.
+func (d *policyDispatcher) rollbackSubscription(subID uint64, registration *policyRegistration) {
+	d.mu.Lock()
+	sub, exists := d.subscriptions[subID]
+	if exists {
+		delete(d.subscriptions, subID)
+	}
+	if registration != nil {
+		delete(d.registrations, registration.id)
+		remaining := d.registeredByGroup[registration.groupKey] &^ registration.conditions
+		if remaining == 0 {
+			delete(d.registeredByGroup, registration.groupKey)
+		} else {
+			d.registeredByGroup[registration.groupKey] = remaining
 		}
+	}
+	d.mu.Unlock()
 
-		paramMap[pciePolicyIndex] = policyConditionParam{
-			typ:   policyFieldTypeBool,
-			value: policyBoolValue,
-		}
-
-		paramMap[maxRtPgPolicyIndex] = policyConditionParam{
-			typ:   policyFieldTypeLong,
-			value: policyMaxRtPgThreshold,
-		}
-
-		paramMap[thermalPolicyIndex] = policyConditionParam{
-			typ:   policyFieldTypeLong,
-			value: policyThermalThreshold,
-		}
-
-		paramMap[powerPolicyIndex] = policyConditionParam{
-			typ:   policyFieldTypeLong,
-			value: policyPowerThreshold,
-		}
-
-		paramMap[nvlinkPolicyIndex] = policyConditionParam{
-			typ:   policyFieldTypeBool,
-			value: policyBoolValue,
-		}
-
-		paramMap[xidPolicyIndex] = policyConditionParam{
-			typ:   policyFieldTypeBool,
-			value: policyBoolValue,
-		}
-	})
+	if exists {
+		close(sub.ch)
+	}
 }
 
-// ViolationRegistration is a go callback function for dcgmPolicyRegister() wrapped in C.violationNotify()
+// unsubscribe closes one listener and unregisters DCGM callbacks when it was the last one.
+func (d *policyDispatcher) unsubscribe(subID uint64) {
+	d.registerMu.Lock()
+	defer d.registerMu.Unlock()
+
+	ch, unregisters := d.removeSubscription(subID)
+	if ch == nil {
+		return
+	}
+	close(ch)
+
+	succeeded := make([]policyUnregister, 0, len(unregisters))
+	for _, unregister := range unregisters {
+		if err := unregisterPolicy(unregister.group, unregister.condition); err != nil {
+			if unregisterErrorClearsLocalState(err) {
+				log.Printf("policy unregister found no live DCGM registration for group %d condition %d: %v",
+					unregister.group.GetHandle(), unregister.condition, err)
+				succeeded = append(succeeded, unregister)
+				continue
+			}
+
+			log.Printf("error unregistering policy for group %d condition %d: %v; retrying once",
+				unregister.group.GetHandle(), unregister.condition, err)
+			if retryErr := unregisterPolicy(unregister.group, unregister.condition); retryErr != nil {
+				if unregisterErrorClearsLocalState(retryErr) {
+					log.Printf("policy unregister retry found no live DCGM registration for group %d condition %d: %v",
+						unregister.group.GetHandle(), unregister.condition, retryErr)
+					succeeded = append(succeeded, unregister)
+					continue
+				}
+
+				log.Printf("error unregistering policy for group %d condition %d after retry: %v",
+					unregister.group.GetHandle(), unregister.condition, retryErr)
+				continue
+			}
+		}
+		succeeded = append(succeeded, unregister)
+	}
+	d.clearRegistrations(succeeded)
+}
+
+// deliver fans out a violation to interested subscribers without blocking.
+func (d *policyDispatcher) deliver(registrationID uint64, violation PolicyViolation) {
+	condition, ok := policyConditionMask(violation.Condition)
+	if !ok {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	registration, exists := d.registrations[registrationID]
+	if !exists {
+		return
+	}
+
+	for _, subscription := range d.subscriptions {
+		if subscription.groupKey != registration.groupKey || subscription.conditions&condition == 0 {
+			continue
+		}
+
+		select {
+		case subscription.ch <- violation:
+		default:
+			d.drops.Add(1)
+		}
+	}
+}
+
+// dropped returns the process-local count of best-effort delivery drops.
+func (d *policyDispatcher) dropped() uint64 {
+	return d.drops.Load()
+}
+
+// policyConditionMask returns the DCGM mask for a public policy condition.
+func policyConditionMask(condition PolicyCondition) (C.dcgmPolicyCondition_t, bool) {
+	return policyConditionInfo(condition)
+}
+
+// policyConditionInfo maps public policy conditions to DCGM condition masks.
+func policyConditionInfo(condition PolicyCondition) (C.dcgmPolicyCondition_t, bool) {
+	switch condition {
+	case DbePolicy:
+		return C.DCGM_POLICY_COND_DBE, true
+	case PCIePolicy:
+		return C.DCGM_POLICY_COND_PCI, true
+	case MaxRtPgPolicy:
+		return C.DCGM_POLICY_COND_MAX_PAGES_RETIRED, true
+	case ThermalPolicy:
+		return C.DCGM_POLICY_COND_THERMAL, true
+	case PowerPolicy:
+		return C.DCGM_POLICY_COND_POWER, true
+	case NvlinkPolicy:
+		return C.DCGM_POLICY_COND_NVLINK, true
+	case XidPolicy:
+		return C.DCGM_POLICY_COND_XID, true
+	default:
+		return 0, false
+	}
+}
+
+// translateConditions validates requested conditions and builds their DCGM mask.
+func translateConditions(conditions []PolicyCondition) (translatedPolicyConditions, error) {
+	if len(conditions) == 0 {
+		return translatedPolicyConditions{}, fmt.Errorf("at least one policy condition must be provided")
+	}
+
+	var translated translatedPolicyConditions
+	for _, condition := range conditions {
+		mask, ok := policyConditionInfo(condition)
+		if !ok {
+			return translatedPolicyConditions{}, fmt.Errorf("unknown policy condition: %s", condition)
+		}
+		translated.condition |= mask
+	}
+
+	return translated, nil
+}
+
+var policyConditionOrder = []PolicyCondition{
+	DbePolicy,
+	PCIePolicy,
+	MaxRtPgPolicy,
+	ThermalPolicy,
+	PowerPolicy,
+	NvlinkPolicy,
+	XidPolicy,
+}
+
+// ensurePolicyForListen preserves existing policy config before a Listen subscription.
+func ensurePolicyForListen(groupID GroupHandle, requested []PolicyCondition) error {
+	status, err := getPolicyForGroup(groupID)
+	if err != nil {
+		if !policyReadNeedsDefaultSetup(err) {
+			return fmt.Errorf("error getting policy before registering listener: %w", err)
+		}
+
+		configs, _ := policyConfigsForListen(nil, requested)
+		return setPolicyForGroupWithConfig(groupID, configs...)
+	}
+
+	configs, needsUpdate := policyConfigsForListen(status, requested)
+	if !needsUpdate {
+		return nil
+	}
+
+	return setPolicyForGroupWithConfig(groupID, configs...)
+}
+
+// policyReadNeedsDefaultSetup reports whether no usable policy exists yet.
+func policyReadNeedsDefaultSetup(err error) bool {
+	var dcgmErr *Error
+	if !errors.As(err, &dcgmErr) {
+		return false
+	}
+
+	return dcgmErr.Code == C.DCGM_ST_INSUFFICIENT_SIZE ||
+		dcgmErr.Code == C.DCGM_ST_NOT_CONFIGURED
+}
+
+// policyConfigsForListen merges missing Listen conditions into existing policy config.
+func policyConfigsForListen(status *PolicyStatus, requested []PolicyCondition) ([]PolicyConfig, bool) {
+	if status == nil {
+		status = &PolicyStatus{
+			Conditions: make(map[PolicyCondition]interface{}),
+		}
+	}
+	if status.Conditions == nil {
+		status.Conditions = make(map[PolicyCondition]interface{})
+	}
+
+	missing := make(map[PolicyCondition]struct{})
+	for _, condition := range requested {
+		if _, exists := status.Conditions[condition]; !exists {
+			missing[condition] = struct{}{}
+		}
+	}
+	if len(missing) == 0 {
+		return nil, false
+	}
+
+	configs := make([]PolicyConfig, 0, len(status.Conditions)+len(missing))
+	for _, condition := range policyConditionOrder {
+		if value, exists := status.Conditions[condition]; exists {
+			configs = append(configs, policyConfigFromStatus(condition, value))
+			continue
+		}
+		if _, needsDefault := missing[condition]; needsDefault {
+			configs = append(configs, defaultPolicyConfig(condition))
+		}
+	}
+
+	if len(configs) > 0 {
+		configs[0].Action = policyActionPtr(status.Action)
+		configs[0].Validation = policyValidationPtr(status.Validation)
+	}
+
+	return configs, true
+}
+
+// policyConfigFromStatus converts a current policy condition into a set config.
+func policyConfigFromStatus(condition PolicyCondition, value interface{}) PolicyConfig {
+	config := PolicyConfig{Condition: condition}
+
+	switch condition {
+	case MaxRtPgPolicy:
+		config.MaxRetiredPages = uint32PolicyPtr(policyThresholdUint32(value, DefaultMaxRetiredPages))
+	case ThermalPolicy:
+		config.MaxTemperature = uint32PolicyPtr(policyThresholdUint32(value, DefaultMaxTemperature))
+	case PowerPolicy:
+		config.MaxPower = uint32PolicyPtr(policyThresholdUint32(value, DefaultMaxPower))
+	}
+
+	return config
+}
+
+// defaultPolicyConfig returns default thresholds for a missing condition.
+func defaultPolicyConfig(condition PolicyCondition) PolicyConfig {
+	switch condition {
+	case MaxRtPgPolicy:
+		return PolicyConfig{
+			Condition:       condition,
+			MaxRetiredPages: uint32PolicyPtr(DefaultMaxRetiredPages),
+		}
+	case ThermalPolicy:
+		return PolicyConfig{
+			Condition:      condition,
+			MaxTemperature: uint32PolicyPtr(DefaultMaxTemperature),
+		}
+	case PowerPolicy:
+		return PolicyConfig{
+			Condition: condition,
+			MaxPower:  uint32PolicyPtr(DefaultMaxPower),
+		}
+	default:
+		return PolicyConfig{Condition: condition}
+	}
+}
+
+// policyThresholdUint32 normalizes numeric thresholds read from DCGM policy status.
+func policyThresholdUint32(value interface{}, defaultValue uint32) uint32 {
+	switch v := value.(type) {
+	case uint32:
+		return v
+	case uint:
+		return uint32(v)
+	case int:
+		if v >= 0 {
+			return uint32(v)
+		}
+	case int32:
+		if v >= 0 {
+			return uint32(v)
+		}
+	case int64:
+		if v >= 0 {
+			return uint32(v)
+		}
+	}
+
+	return defaultValue
+}
+
+// uint32PolicyPtr returns a stable pointer for PolicyConfig threshold fields.
+func uint32PolicyPtr(value uint32) *uint32 {
+	return &value
+}
+
+// policyActionPtr returns a stable pointer for PolicyConfig action.
+func policyActionPtr(value PolicyAction) *PolicyAction {
+	return &value
+}
+
+// policyValidationPtr returns a stable pointer for PolicyConfig validation.
+func policyValidationPtr(value PolicyValidation) *PolicyValidation {
+	return &value
+}
+
+// ViolationRegistration decodes a DCGM callback and dispatches by registration ID.
 //
 //export ViolationRegistration
-func ViolationRegistration(data unsafe.Pointer) int {
+func ViolationRegistration(data unsafe.Pointer, userData C.uint64_t) C.int {
 	var con PolicyCondition
 	var timestamp time.Time
 	var val any
@@ -370,61 +732,9 @@ func ViolationRegistration(data unsafe.Pointer) int {
 		Data:      val,
 	}
 
-	switch con {
-	case DbePolicy:
-		callbacks["dbe"] <- err
-	case PCIePolicy:
-		callbacks["pcie"] <- err
-	case MaxRtPgPolicy:
-		callbacks["maxrtpg"] <- err
-	case ThermalPolicy:
-		callbacks["thermal"] <- err
-	case PowerPolicy:
-		callbacks["power"] <- err
-	case NvlinkPolicy:
-		callbacks["nvlink"] <- err
-	case XidPolicy:
-		callbacks["xid"] <- err
-	}
+	policyCallbacks.deliver(uint64(userData), err)
+
 	return 0
-}
-
-func setPolicy(groupID GroupHandle, condition C.dcgmPolicyCondition_t, paramList []policyIndex) (err error) {
-	var policy C.dcgmPolicy_t
-	policy.version = makeVersion1(unsafe.Sizeof(policy))
-	policy.mode = C.dcgmPolicyMode_t(C.DCGM_OPERATION_MODE_AUTO)
-	policy.action = C.DCGM_POLICY_ACTION_NONE
-	policy.isolation = C.DCGM_POLICY_ISOLATION_NONE
-	policy.validation = C.DCGM_POLICY_VALID_NONE
-	policy.condition = condition
-
-	// iterate on paramMap for given policy conditions
-	for _, key := range paramList {
-		conditionParam, exists := paramMap[key]
-		if !exists {
-			return fmt.Errorf("invalid policy condition: %v does not exist", key)
-		}
-		// set policy condition parameters
-		// set condition type (bool or longlong)
-		policy.parms[key].tag = conditionParam.typ
-
-		// set condition val (violation threshold)
-		// policy.parms.val is a C union type
-		// cgo docs: Go doesn't have support for C's union type
-		// C union types are represented as a Go byte array
-		binary.LittleEndian.PutUint32(policy.parms[key].val[:], conditionParam.value)
-	}
-
-	var statusHandle C.dcgmStatus_t
-
-	result := C.dcgmPolicySet(handle.handle, groupID.handle, &policy, statusHandle)
-	if err = errorString(result); err != nil {
-		return fmt.Errorf("error setting policies: %s", err)
-	}
-
-	log.Println("Policy successfully set.")
-
-	return
 }
 
 func setPolicyInternal(groupID GroupHandle, condition C.dcgmPolicyCondition_t, configs []policyConfigInternal, action PolicyAction, validation PolicyValidation) (err error) {
@@ -480,6 +790,7 @@ type PolicyStatus struct {
 	Conditions map[PolicyCondition]interface{}
 }
 
+// getPolicyForGroup returns current policy config while preserving DCGM error codes.
 func getPolicyForGroup(groupID GroupHandle) (*PolicyStatus, error) {
 	var policy C.dcgmPolicy_t
 	policy.version = makeVersion1(unsafe.Sizeof(policy))
@@ -488,7 +799,7 @@ func getPolicyForGroup(groupID GroupHandle) (*PolicyStatus, error) {
 
 	result := C.dcgmPolicyGet(handle.handle, groupID.handle, 1, &policy, statusHandle)
 	if err := errorString(result); err != nil {
-		return nil, fmt.Errorf("error getting policy: %s", err)
+		return nil, &Error{msg: fmt.Sprintf("error getting policy: %s", err), Code: result}
 	}
 
 	status := &PolicyStatus{
@@ -677,234 +988,101 @@ func setPolicyForGroupWithConfig(groupID GroupHandle, configs ...PolicyConfig) e
 	return setPolicyInternal(groupID, condition, internalConfigs, action, validation)
 }
 
+// registerPolicy configures requested policy conditions before subscribing.
 func registerPolicy(ctx context.Context, groupID GroupHandle, typ ...PolicyCondition) (<-chan PolicyViolation, error) {
-	var err error
-	// init policy globals for internal API
-	makePolicyChannels()
-	makePolicyParmsMap()
-
-	// Increment active listener count
-	policyCleanupMux.Lock()
-	activeListeners++
-	policyCleanupMux.Unlock()
-
-	// make a list of policy conditions for setting their parameters
-	paramKeys := make([]policyIndex, len(typ))
-	// get all conditions to be set in setPolicy()
-	var condition C.dcgmPolicyCondition_t = 0
-
-	for i, t := range typ {
-		switch t {
-		case DbePolicy:
-			paramKeys[i] = dbePolicyIndex
-			condition |= C.DCGM_POLICY_COND_DBE
-		case PCIePolicy:
-			paramKeys[i] = pciePolicyIndex
-			condition |= C.DCGM_POLICY_COND_PCI
-		case MaxRtPgPolicy:
-			paramKeys[i] = maxRtPgPolicyIndex
-			condition |= C.DCGM_POLICY_COND_MAX_PAGES_RETIRED
-		case ThermalPolicy:
-			paramKeys[i] = thermalPolicyIndex
-			condition |= C.DCGM_POLICY_COND_THERMAL
-		case PowerPolicy:
-			paramKeys[i] = powerPolicyIndex
-			condition |= C.DCGM_POLICY_COND_POWER
-		case NvlinkPolicy:
-			paramKeys[i] = nvlinkPolicyIndex
-			condition |= C.DCGM_POLICY_COND_NVLINK
-		case XidPolicy:
-			paramKeys[i] = xidPolicyIndex
-			condition |= C.DCGM_POLICY_COND_XID
-		}
+	if ctx == nil {
+		return nil, fmt.Errorf("context must not be nil")
 	}
 
-	err = setPolicy(groupID, condition, paramKeys)
+	translated, err := translateConditions(typ)
 	if err != nil {
-		policyCleanupMux.Lock()
-		activeListeners--
-		policyCleanupMux.Unlock()
 		return nil, err
 	}
 
-	result := C.dcgmPolicyRegister_v2(handle.handle, groupID.handle, condition, C.fpRecvUpdates(C.violationNotify), C.ulong(0))
+	return subscribePolicy(ctx, groupID, translated.condition, len(typ), func() error {
+		return ensurePolicyForListen(groupID, typ)
+	})
+}
 
-	if err = errorString(result); err != nil {
-		policyCleanupMux.Lock()
-		activeListeners--
-		policyCleanupMux.Unlock()
-		return nil, &Error{msg: C.GoString(C.errorString(result)), Code: result}
+// registerPolicyOnly subscribes to existing policy conditions without changing thresholds.
+func registerPolicyOnly(ctx context.Context, groupID GroupHandle, typ ...PolicyCondition) (<-chan PolicyViolation, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("context must not be nil")
 	}
+
+	translated, err := translateConditions(typ)
+	if err != nil {
+		return nil, err
+	}
+
+	return subscribePolicy(ctx, groupID, translated.condition, len(typ), nil)
+}
+
+// subscribePolicy serializes local subscription setup and DCGM registration.
+func subscribePolicy(
+	ctx context.Context,
+	groupID GroupHandle,
+	condition C.dcgmPolicyCondition_t,
+	buffer int,
+	setup func() error,
+) (<-chan PolicyViolation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	policyCallbacks.registerMu.Lock()
+	defer policyCallbacks.registerMu.Unlock()
+
+	if setup != nil {
+		if err := setup(); err != nil {
+			return nil, err
+		}
+	}
+
+	subID, violation, registration := policyCallbacks.addSubscription(groupID, condition, buffer)
+	if registration != nil {
+		result := C.dcgmPolicyRegister_v2(
+			handle.handle,
+			groupID.handle,
+			registration.conditions,
+			C.fpRecvUpdates(C.violationNotify),
+			C.uint64_t(registration.id),
+		)
+		if err := errorString(result); err != nil {
+			policyCallbacks.rollbackSubscription(subID, registration)
+			return nil, &Error{msg: C.GoString(C.errorString(result)), Code: result}
+		}
+	}
+
+	context.AfterFunc(ctx, func() {
+		policyCallbacks.unsubscribe(subID)
+	})
 
 	log.Println("Listening for violations...")
 
-	violation := make(chan PolicyViolation, len(typ))
-
-	go func() {
-		defer func() {
-			log.Println("unregister policy violation...")
-			close(violation)
-			unregisterPolicy(groupID, condition)
-
-			// Decrement active listener count and cleanup if needed
-			policyCleanupMux.Lock()
-			activeListeners--
-			policyCleanupMux.Unlock()
-			cleanupPolicyChannels()
-		}()
-
-		for {
-			select {
-			case dbe, ok := <-callbacks["dbe"]:
-				if !ok {
-					return
-				}
-				violation <- dbe
-			case pcie, ok := <-callbacks["pcie"]:
-				if !ok {
-					return
-				}
-				violation <- pcie
-			case maxrtpg, ok := <-callbacks["maxrtpg"]:
-				if !ok {
-					return
-				}
-				violation <- maxrtpg
-			case thermal, ok := <-callbacks["thermal"]:
-				if !ok {
-					return
-				}
-				violation <- thermal
-			case power, ok := <-callbacks["power"]:
-				if !ok {
-					return
-				}
-				violation <- power
-			case nvlink, ok := <-callbacks["nvlink"]:
-				if !ok {
-					return
-				}
-				violation <- nvlink
-			case xid, ok := <-callbacks["xid"]:
-				if !ok {
-					return
-				}
-				violation <- xid
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	return violation, err
+	return violation, nil
 }
 
-func registerPolicyOnly(ctx context.Context, groupID GroupHandle, typ ...PolicyCondition) (<-chan PolicyViolation, error) {
-	var err error
-	// init policy globals for internal API
-	makePolicyChannels()
-
-	policyCleanupMux.Lock()
-	activeListeners++
-	policyCleanupMux.Unlock()
-
-	// get all conditions to listen for
-	var condition C.dcgmPolicyCondition_t = 0
-
-	for _, t := range typ {
-		switch t {
-		case DbePolicy:
-			condition |= C.DCGM_POLICY_COND_DBE
-		case PCIePolicy:
-			condition |= C.DCGM_POLICY_COND_PCI
-		case MaxRtPgPolicy:
-			condition |= C.DCGM_POLICY_COND_MAX_PAGES_RETIRED
-		case ThermalPolicy:
-			condition |= C.DCGM_POLICY_COND_THERMAL
-		case PowerPolicy:
-			condition |= C.DCGM_POLICY_COND_POWER
-		case NvlinkPolicy:
-			condition |= C.DCGM_POLICY_COND_NVLINK
-		case XidPolicy:
-			condition |= C.DCGM_POLICY_COND_XID
-		}
-	}
-
-	// Register for violations without setting policies
-	result := C.dcgmPolicyRegister_v2(handle.handle, groupID.handle, condition, C.fpRecvUpdates(C.violationNotify), C.ulong(0))
-
-	if err = errorString(result); err != nil {
-		policyCleanupMux.Lock()
-		activeListeners--
-		policyCleanupMux.Unlock()
-		return nil, &Error{msg: C.GoString(C.errorString(result)), Code: result}
-	}
-
-	violation := make(chan PolicyViolation, len(typ))
-
-	go func() {
-		defer func() {
-			close(violation)
-			unregisterPolicy(groupID, condition)
-
-			policyCleanupMux.Lock()
-			activeListeners--
-			policyCleanupMux.Unlock()
-			cleanupPolicyChannels()
-		}()
-
-		for {
-			select {
-			case dbe, ok := <-callbacks["dbe"]:
-				if !ok {
-					return
-				}
-				violation <- dbe
-			case pcie, ok := <-callbacks["pcie"]:
-				if !ok {
-					return
-				}
-				violation <- pcie
-			case maxrtpg, ok := <-callbacks["maxrtpg"]:
-				if !ok {
-					return
-				}
-				violation <- maxrtpg
-			case thermal, ok := <-callbacks["thermal"]:
-				if !ok {
-					return
-				}
-				violation <- thermal
-			case power, ok := <-callbacks["power"]:
-				if !ok {
-					return
-				}
-				violation <- power
-			case nvlink, ok := <-callbacks["nvlink"]:
-				if !ok {
-					return
-				}
-				violation <- nvlink
-			case xid, ok := <-callbacks["xid"]:
-				if !ok {
-					return
-				}
-				violation <- xid
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-
-	return violation, err
-}
-
-func unregisterPolicy(groupID GroupHandle, condition C.dcgmPolicyCondition_t) {
+// unregisterPolicy unregisters DCGM callbacks for a group condition mask.
+func unregisterPolicy(groupID GroupHandle, condition C.dcgmPolicyCondition_t) error {
 	result := C.dcgmPolicyUnregister(handle.handle, groupID.handle, condition)
 
 	if err := errorString(result); err != nil {
-		log.Println(fmt.Errorf("error unregistering policy: %s", err))
+		return &Error{msg: fmt.Sprintf("error unregistering policy: %s", err), Code: result}
 	}
+
+	return nil
+}
+
+// unregisterErrorClearsLocalState reports whether DCGM state is already gone.
+func unregisterErrorClearsLocalState(err error) bool {
+	var dcgmErr *Error
+	if !errors.As(err, &dcgmErr) {
+		return false
+	}
+
+	return dcgmErr.Code == C.DCGM_ST_UNINITIALIZED ||
+		dcgmErr.Code == C.DCGM_ST_CONNECTION_NOT_VALID
 }
 
 func createTimeStamp(t C.longlong) time.Time {

--- a/pkg/dcgm/policy.go
+++ b/pkg/dcgm/policy.go
@@ -198,6 +198,7 @@ type translatedPolicyConditions struct {
 
 type policySubscription struct {
 	id         uint64
+	group      GroupHandle
 	groupKey   uintptr
 	conditions C.dcgmPolicyCondition_t
 	ch         chan PolicyViolation
@@ -264,6 +265,7 @@ func (d *policyDispatcher) addSubscription(
 	ch := make(chan PolicyViolation, buffer)
 	d.subscriptions[subID] = &policySubscription{
 		id:         subID,
+		group:      group,
 		groupKey:   groupKey,
 		conditions: conditions,
 		ch:         ch,
@@ -287,7 +289,7 @@ func (d *policyDispatcher) addSubscription(
 	return subID, ch, &registration
 }
 
-// removeSubscription removes one listener and returns final-subscriber unregister work.
+// removeSubscription removes one listener and returns newly unused DCGM conditions.
 func (d *policyDispatcher) removeSubscription(subID uint64) (chan PolicyViolation, []policyUnregister) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -298,31 +300,27 @@ func (d *policyDispatcher) removeSubscription(subID uint64) (chan PolicyViolatio
 	}
 	delete(d.subscriptions, subID)
 
-	if len(d.subscriptions) > 0 {
-		// Per-group teardown is intentionally deferred until the final local subscriber exits.
-		// If one group's subscribers leave while another group remains active, callbacks for
-		// the first group can still enter Go, but deliver drops them because no subscription
-		// matches that group. This keeps lifecycle ownership simple until per-group refcounts
-		// are needed.
+	registered := d.registeredByGroup[sub.groupKey]
+	if registered == 0 {
 		return sub.ch, nil
 	}
 
-	unregisterByGroup := make(map[uintptr]policyUnregister)
-	for _, registration := range d.registrations {
-		entry := unregisterByGroup[registration.groupKey]
-		if entry.condition == 0 {
-			entry.group = registration.group
+	var stillNeeded C.dcgmPolicyCondition_t
+	for _, subscription := range d.subscriptions {
+		if subscription.groupKey == sub.groupKey {
+			stillNeeded |= subscription.conditions
 		}
-		entry.condition |= registration.conditions
-		unregisterByGroup[registration.groupKey] = entry
 	}
 
-	unregisters := make([]policyUnregister, 0, len(unregisterByGroup))
-	for _, entry := range unregisterByGroup {
-		unregisters = append(unregisters, entry)
+	unused := registered &^ stillNeeded
+	if unused == 0 {
+		return sub.ch, nil
 	}
 
-	return sub.ch, unregisters
+	return sub.ch, []policyUnregister{{
+		group:     sub.group,
+		condition: unused,
+	}}
 }
 
 // clearRegistrations removes bookkeeping for DCGM registrations that are gone.
@@ -383,7 +381,7 @@ func (d *policyDispatcher) rollbackSubscription(subID uint64, registration *poli
 	}
 }
 
-// unsubscribe closes one listener and unregisters DCGM callbacks when it was the last one.
+// unsubscribe closes one listener and unregisters conditions no remaining listener needs.
 func (d *policyDispatcher) unsubscribe(subID uint64) {
 	d.registerMu.Lock()
 	defer d.registerMu.Unlock()

--- a/pkg/dcgm/policy_dispatcher_test.go
+++ b/pkg/dcgm/policy_dispatcher_test.go
@@ -1,0 +1,377 @@
+//go:build linux && cgo
+
+package dcgm
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterUnknownConditionErrors(t *testing.T) {
+	_, err := translateConditions(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one policy condition")
+
+	_, err = translateConditions([]PolicyCondition{PolicyCondition("unknown policy")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown policy condition")
+}
+
+func TestConcurrentPolicySubscribers(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1001)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	_, first, registration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, registration)
+
+	_, second, duplicateRegistration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.Nil(t, duplicateRegistration)
+
+	violation := PolicyViolation{
+		Condition: XidPolicy,
+		Data:      XidPolicyCondition{ErrNum: 79},
+	}
+	dispatcher.deliver(registration.id, violation)
+
+	assert.Equal(t, violation, receivePolicyViolation(t, first))
+	assert.Equal(t, violation, receivePolicyViolation(t, second))
+}
+
+func TestPolicyDispatcherSlowConsumerDrop(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1002)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	_, slow, registration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, registration)
+	_, fast, _ := dispatcher.addSubscription(group, xidCondition, 1)
+
+	first := PolicyViolation{
+		Condition: XidPolicy,
+		Data:      XidPolicyCondition{ErrNum: 31},
+	}
+	second := PolicyViolation{
+		Condition: XidPolicy,
+		Data:      XidPolicyCondition{ErrNum: 79},
+	}
+
+	dispatcher.deliver(registration.id, first)
+	assert.Equal(t, first, receivePolicyViolation(t, fast))
+
+	done := make(chan struct{})
+	go func() {
+		dispatcher.deliver(registration.id, second)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("deliver blocked on a full subscriber channel")
+	}
+
+	assert.Equal(t, second, receivePolicyViolation(t, fast))
+	assert.Equal(t, uint64(1), dispatcher.dropped())
+	assert.Equal(t, first, receivePolicyViolation(t, slow))
+	assertNoPolicyViolation(t, slow)
+}
+
+func TestPolicyListenerLifecycle(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1003)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	firstID, first, registration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, registration)
+	_, second, _ := dispatcher.addSubscription(group, xidCondition, 1)
+
+	closed, unregisters := dispatcher.removeSubscription(firstID)
+	require.Equal(t, first, closed)
+	assert.Empty(t, unregisters)
+	close(closed)
+
+	_, channelOpen := <-first
+	assert.False(t, channelOpen)
+
+	violation := PolicyViolation{
+		Condition: XidPolicy,
+		Data:      XidPolicyCondition{ErrNum: 43},
+	}
+	dispatcher.deliver(registration.id, violation)
+
+	assert.Equal(t, violation, receivePolicyViolation(t, second))
+}
+
+func TestPolicyDispatcherDifferentGroupsIsolated(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	_, groupA, registrationA := dispatcher.addSubscription(
+		policyTestGroupHandle(2001),
+		xidCondition,
+		1,
+	)
+	require.NotNil(t, registrationA)
+	_, groupB, registrationB := dispatcher.addSubscription(
+		policyTestGroupHandle(2002),
+		xidCondition,
+		1,
+	)
+	require.NotNil(t, registrationB)
+
+	violation := PolicyViolation{
+		Condition: XidPolicy,
+		Data:      XidPolicyCondition{ErrNum: 95},
+	}
+	dispatcher.deliver(registrationA.id, violation)
+
+	assert.Equal(t, violation, receivePolicyViolation(t, groupA))
+	assertNoPolicyViolation(t, groupB)
+}
+
+func TestPolicyDispatcherFinalSubscriberReset(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1004)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	firstID, first, registration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, registration)
+
+	closed, unregisters := dispatcher.removeSubscription(firstID)
+	require.Equal(t, first, closed)
+	require.Len(t, unregisters, 1)
+	assert.Equal(t, xidCondition, unregisters[0].condition)
+	close(closed)
+
+	dispatcher.mu.Lock()
+	assert.Contains(t, dispatcher.registrations, registration.id)
+	assert.Equal(t, xidCondition, dispatcher.registeredByGroup[group.GetHandle()])
+	dispatcher.mu.Unlock()
+
+	dispatcher.clearRegistrations(unregisters)
+
+	_, second, nextRegistration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, nextRegistration)
+	require.NotEqual(t, registration.id, nextRegistration.id)
+	close(second)
+}
+
+func TestPolicyDispatcherClearRegistrationKeepsStateOnUnregisterFailure(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1005)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	firstID, first, registration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, registration)
+
+	closed, unregisters := dispatcher.removeSubscription(firstID)
+	require.Equal(t, first, closed)
+	require.Len(t, unregisters, 1)
+	close(closed)
+
+	_, next, nextRegistration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.Nil(t, nextRegistration)
+
+	violation := PolicyViolation{
+		Condition: XidPolicy,
+		Data:      XidPolicyCondition{ErrNum: 48},
+	}
+	dispatcher.deliver(registration.id, violation)
+	assert.Equal(t, violation, receivePolicyViolation(t, next))
+}
+
+func TestPolicyDispatcherRollbackSubscription(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1006)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	subID, ch, registration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, registration)
+
+	dispatcher.rollbackSubscription(subID, registration)
+
+	_, channelOpen := <-ch
+	assert.False(t, channelOpen)
+
+	dispatcher.mu.Lock()
+	assert.Empty(t, dispatcher.subscriptions)
+	assert.Empty(t, dispatcher.registrations)
+	assert.Empty(t, dispatcher.registeredByGroup)
+	dispatcher.mu.Unlock()
+}
+
+func TestPolicyDispatcherDeliverUnknownCondition(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1007)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	_, ch, registration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, registration)
+
+	dispatcher.deliver(registration.id, PolicyViolation{Condition: PolicyCondition("unknown policy")})
+
+	assertNoPolicyViolation(t, ch)
+	assert.Equal(t, uint64(0), dispatcher.dropped())
+}
+
+func TestUnregisterErrorClearsLocalStateOnlyWhenRegistrationCannotBeLive(t *testing.T) {
+	assert.True(t, unregisterErrorClearsLocalState(&Error{Code: -10}))
+	assert.True(t, unregisterErrorClearsLocalState(&Error{Code: -21}))
+	assert.False(t, unregisterErrorClearsLocalState(&Error{Code: -34}))
+}
+
+func TestPolicyReadNeedsDefaultSetupOnlyForMissingPolicyErrors(t *testing.T) {
+	assert.True(t, policyReadNeedsDefaultSetup(&Error{Code: -31}))
+	assert.True(t, policyReadNeedsDefaultSetup(&Error{Code: -5}))
+
+	assert.False(t, policyReadNeedsDefaultSetup(&Error{Code: -8}))
+	assert.False(t, policyReadNeedsDefaultSetup(&Error{Code: -21}))
+	assert.False(t, policyReadNeedsDefaultSetup(assert.AnError))
+}
+
+func TestPolicyDispatcherDeliverDuringUnsubscribeRace(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1008)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	subID, ch, registration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, registration)
+
+	violation := PolicyViolation{
+		Condition: XidPolicy,
+		Data:      XidPolicyCondition{ErrNum: 79},
+	}
+
+	start := make(chan struct{})
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					dispatcher.deliver(registration.id, violation)
+				}
+			}
+		}()
+	}
+
+	close(start)
+	time.Sleep(10 * time.Millisecond)
+
+	closed, unregisters := dispatcher.removeSubscription(subID)
+	require.Equal(t, ch, closed)
+	require.Len(t, unregisters, 1)
+	close(closed)
+
+	close(stop)
+	wg.Wait()
+}
+
+func TestPolicyConfigsForListenPreserveExistingThresholds(t *testing.T) {
+	status := &PolicyStatus{
+		Action:     PolicyActionGPUReset,
+		Validation: PolicyValidationShort,
+		Conditions: map[PolicyCondition]interface{}{
+			ThermalPolicy: uint32(85),
+		},
+	}
+
+	configs, needsUpdate := policyConfigsForListen(status, []PolicyCondition{ThermalPolicy, XidPolicy})
+
+	require.True(t, needsUpdate)
+	require.Len(t, configs, 2)
+	assert.Equal(t, ThermalPolicy, configs[0].Condition)
+	require.NotNil(t, configs[0].MaxTemperature)
+	assert.Equal(t, uint32(85), *configs[0].MaxTemperature)
+	require.NotNil(t, configs[0].Action)
+	assert.Equal(t, PolicyActionGPUReset, *configs[0].Action)
+	require.NotNil(t, configs[0].Validation)
+	assert.Equal(t, PolicyValidationShort, *configs[0].Validation)
+	assert.Equal(t, XidPolicy, configs[1].Condition)
+}
+
+func TestPolicyConfigsForListenNoopWhenRequestedConditionsExist(t *testing.T) {
+	status := &PolicyStatus{
+		Conditions: map[PolicyCondition]interface{}{
+			XidPolicy: true,
+		},
+	}
+
+	configs, needsUpdate := policyConfigsForListen(status, []PolicyCondition{XidPolicy})
+
+	assert.False(t, needsUpdate)
+	assert.Empty(t, configs)
+}
+
+func TestPolicyViolationDropCount(t *testing.T) {
+	previousCallbacks := policyCallbacks
+	dispatcher := newPolicyDispatcher()
+	policyCallbacks = dispatcher
+	t.Cleanup(func() {
+		policyCallbacks = previousCallbacks
+	})
+
+	group := policyTestGroupHandle(1009)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	_, ch, registration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, registration)
+
+	dispatcher.deliver(registration.id, PolicyViolation{Condition: XidPolicy})
+	dispatcher.deliver(registration.id, PolicyViolation{Condition: XidPolicy})
+
+	assert.Equal(t, uint64(1), PolicyViolationDropCount())
+	_ = receivePolicyViolation(t, ch)
+}
+
+func policyTestGroupHandle(id uintptr) GroupHandle {
+	var group GroupHandle
+	group.SetHandle(id)
+	return group
+}
+
+func receivePolicyViolation(t *testing.T, ch <-chan PolicyViolation) PolicyViolation {
+	t.Helper()
+
+	select {
+	case violation, ok := <-ch:
+		require.True(t, ok, "policy violation channel closed")
+		return violation
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for policy violation")
+		return PolicyViolation{}
+	}
+}
+
+func assertNoPolicyViolation(t *testing.T, ch <-chan PolicyViolation) {
+	t.Helper()
+
+	select {
+	case violation, ok := <-ch:
+		if ok {
+			t.Fatalf("unexpected policy violation: %+v", violation)
+		}
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/pkg/dcgm/policy_dispatcher_test.go
+++ b/pkg/dcgm/policy_dispatcher_test.go
@@ -166,6 +166,104 @@ func TestPolicyDispatcherFinalSubscriberReset(t *testing.T) {
 	close(second)
 }
 
+func TestPolicyDispatcherSameGroupUnregistersOnlyUnusedCondition(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1010)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+	thermalCondition, ok := policyConditionMask(ThermalPolicy)
+	require.True(t, ok)
+
+	xidSubID, xidCh, xidRegistration := dispatcher.addSubscription(group, xidCondition, 1)
+	require.NotNil(t, xidRegistration)
+	_, thermalCh, thermalRegistration := dispatcher.addSubscription(group, thermalCondition, 1)
+	require.NotNil(t, thermalRegistration)
+
+	closed, unregisters := dispatcher.removeSubscription(xidSubID)
+	require.Equal(t, xidCh, closed)
+	require.Len(t, unregisters, 1)
+	assert.Equal(t, xidCondition, unregisters[0].condition)
+	close(closed)
+
+	dispatcher.clearRegistrations(unregisters)
+
+	dispatcher.mu.Lock()
+	assert.Equal(t, thermalCondition, dispatcher.registeredByGroup[group.GetHandle()])
+	assert.NotContains(t, dispatcher.registrations, xidRegistration.id)
+	assert.Contains(t, dispatcher.registrations, thermalRegistration.id)
+	dispatcher.mu.Unlock()
+
+	violation := PolicyViolation{Condition: ThermalPolicy}
+	dispatcher.deliver(thermalRegistration.id, violation)
+	assert.Equal(t, violation, receivePolicyViolation(t, thermalCh))
+}
+
+func TestPolicyDispatcherDifferentGroupsUnregistersUnusedGroupOnly(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	groupA := policyTestGroupHandle(1011)
+	groupB := policyTestGroupHandle(1012)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+
+	groupASubID, groupACh, groupARegistration := dispatcher.addSubscription(groupA, xidCondition, 1)
+	require.NotNil(t, groupARegistration)
+	_, groupBCh, groupBRegistration := dispatcher.addSubscription(groupB, xidCondition, 1)
+	require.NotNil(t, groupBRegistration)
+
+	closed, unregisters := dispatcher.removeSubscription(groupASubID)
+	require.Equal(t, groupACh, closed)
+	require.Len(t, unregisters, 1)
+	assert.Equal(t, groupA.GetHandle(), unregisters[0].group.GetHandle())
+	assert.Equal(t, xidCondition, unregisters[0].condition)
+	close(closed)
+
+	dispatcher.clearRegistrations(unregisters)
+
+	dispatcher.mu.Lock()
+	assert.NotContains(t, dispatcher.registeredByGroup, groupA.GetHandle())
+	assert.NotContains(t, dispatcher.registrations, groupARegistration.id)
+	assert.Equal(t, xidCondition, dispatcher.registeredByGroup[groupB.GetHandle()])
+	assert.Contains(t, dispatcher.registrations, groupBRegistration.id)
+	dispatcher.mu.Unlock()
+
+	violation := PolicyViolation{Condition: XidPolicy}
+	dispatcher.deliver(groupBRegistration.id, violation)
+	assert.Equal(t, violation, receivePolicyViolation(t, groupBCh))
+}
+
+func TestPolicyDispatcherCombinedRegistrationUnregistersOnlyUnusedCondition(t *testing.T) {
+	dispatcher := newPolicyDispatcher()
+	group := policyTestGroupHandle(1013)
+	xidCondition, ok := policyConditionMask(XidPolicy)
+	require.True(t, ok)
+	thermalCondition, ok := policyConditionMask(ThermalPolicy)
+	require.True(t, ok)
+
+	combinedCondition := xidCondition | thermalCondition
+	combinedSubID, combinedCh, combinedRegistration := dispatcher.addSubscription(group, combinedCondition, 2)
+	require.NotNil(t, combinedRegistration)
+	_, thermalCh, thermalRegistration := dispatcher.addSubscription(group, thermalCondition, 1)
+	require.Nil(t, thermalRegistration)
+
+	closed, unregisters := dispatcher.removeSubscription(combinedSubID)
+	require.Equal(t, combinedCh, closed)
+	require.Len(t, unregisters, 1)
+	assert.Equal(t, xidCondition, unregisters[0].condition)
+	close(closed)
+
+	dispatcher.clearRegistrations(unregisters)
+
+	dispatcher.mu.Lock()
+	require.Contains(t, dispatcher.registrations, combinedRegistration.id)
+	assert.Equal(t, thermalCondition, dispatcher.registrations[combinedRegistration.id].conditions)
+	assert.Equal(t, thermalCondition, dispatcher.registeredByGroup[group.GetHandle()])
+	dispatcher.mu.Unlock()
+
+	violation := PolicyViolation{Condition: ThermalPolicy}
+	dispatcher.deliver(combinedRegistration.id, violation)
+	assert.Equal(t, violation, receivePolicyViolation(t, thermalCh))
+}
+
 func TestPolicyDispatcherClearRegistrationKeepsStateOnUnregisterFailure(t *testing.T) {
 	dispatcher := newPolicyDispatcher()
 	group := policyTestGroupHandle(1005)


### PR DESCRIPTION
## Summary

  Fix DCGM policy listener callback handling by replacing shared global callback channels with a per-subscriber dispatcher. This prevents listener fanout races, callback blocking, premature cleanup, and policy threshold
  clobbering while keeping public listener API signatures unchanged.

  Covers:
  - [DCGM-6957](https://jirasw.nvidia.com/browse/DCGM-6957)
  - [DCGM-6956](https://jirasw.nvidia.com/browse/DCGM-6956)
  - [DCGM-6904](https://jirasw.nvidia.com/browse/DCGM-6904)
  - [DCGM-3746](https://jirasw.nvidia.com/browse/DCGM-3746)
  - [DCGM-6905](https://jirasw.nvidia.com/browse/DCGM-6905)

  ## Changes

  - Add an internal policy dispatcher with per-subscriber channels, group-aware routing, and DCGM `userData` registration IDs.
  - Fan out matching policy violations to all interested subscribers instead of competing on shared condition channels.
  - Use non-blocking delivery so slow consumers cannot block DCGM callback threads.
  - Preserve existing policy thresholds for `Listen*` APIs by merging missing conditions instead of resetting the whole policy to defaults.
  - Narrow default policy setup fallback to `DCGM_ST_INSUFFICIENT_SIZE` and `DCGM_ST_NOT_CONFIGURED`; propagate other policy-read errors.
  - Keep unregister bookkeeping until `dcgmPolicyUnregister` succeeds or DCGM reports no live registration can remain.
  - Expose `PolicyViolationDropCount()` for slow-consumer drop visibility.
  - Update C callback bridge to pass DCGM `userData`.
  - Add dispatcher, lifecycle, rollback, race, threshold-preservation, and error-contract tests.

  ## Validation

  - `go test ./pkg/dcgm -count=1`
  - `go test -race ./pkg/dcgm -run "TestPolicyDispatcherDeliverDuringUnsubscribeRace|TestPolicyDispatcherRollbackSubscription|TestPolicyDispatcherClearRegistrationKeepsStateOnUnregisterFailure|
  TestPolicyDispatcherSlowConsumerDrop|TestConcurrentPolicySubscribers|TestPolicyListenerLifecycle" -count=1 -v`
  - `go test ./pkg/dcgm -run "TestPolicyErrors|TestSetPolicyAndWatchViolations|TestSetAndGetPolicy|TestSetAndGetMultiplePolicies" -count=1 -v`
  - `go build ./...`
  - `go vet ./...`

  ### dcgm-exporter L4 Smoke Test

  Built `dcgm-exporter` from `/home/rvatkar/code/dcgm-exporter-dev` against the local fixed `go-dcgm` branch using a temporary `go.work` replace.

  1. Confirm exporter uses local `go-dcgm`:

     ```bash
     cd /home/rvatkar/code/dcgm-exporter-dev
     GOWORK=/tmp/dcgm-exporter-gowork/go.work go list -m -f "{{.Path}} {{.Version}} {{.Dir}}" github.com/NVIDIA/go-dcgm

  Expected: module resolves to /home/rvatkar/code/community/go-dcgm.

  2. Build exporter:

     GOWORK=/tmp/dcgm-exporter-gowork/go.work make binary
  3. Run exporter on L4 host with reduced L4 counters:

     /tmp/dcgm-exporter-after \
       -f /tmp/dcgm-exporter-l4-counters.csv \
       -a :9401 \
       --enable-dcgm-log \
       --dcgm-log-level DEBUG
  4. Scrape metrics:

     curl -sf http://127.0.0.1:9401/metrics >/tmp/dcgm-exporter-after.metrics

     grep -E "DCGM_FI_DEV_GPU_UTIL|DCGM_FI_DEV_SM_CLOCK|DCGM_FI_DEV_FB_USED|DCGM_FI_DEV_XID_ERRORS" \
       /tmp/dcgm-exporter-after.metrics
  5. Repeated scrape soak:

     for i in $(seq 1 30); do
       curl -sf http://127.0.0.1:9401/metrics >/tmp/dcgm-exporter-after-$i.metrics || exit 1
       sleep 10
     done

  Result:

  - Exporter started successfully on L4.
  - Repeated scrapes succeeded.
  - L4 metrics such as DCGM_FI_DEV_SM_CLOCK, DCGM_FI_DEV_GPU_UTIL, and DCGM_FI_DEV_FB_USED were present.
  - No callback panic, deadlock, or exporter crash observed.
  - XID injection was visible when exporter connected to the same hostengine using --remote-hostengine-info localhost:5555.

  ## Notes

  No dcgm-exporter code change is required, but downstream consumers need to update github.com/NVIDIA/go-dcgm dependency to pick up this fix.