### PR TITLE
fix(dcgm): correct DCGM_ST_UNINITIALIZED status code

### DIFF
--- a/pkg/dcgm/const.go
+++ b/pkg/dcgm/const.go
@@ -94,6 +94,8 @@ const (
 	DCGM_ST_NVML_ERROR = -8
 	// DCGM_ST_PENDING is the value for ECC PENDING
 	DCGM_ST_PENDING = -9
+	// DCGM_ST_UNINITIALIZED is the value for DCGM not initialized
+	DCGM_ST_UNINITIALIZED = -10
 	// DCGM_ST_TIMEOUT is the value for ECC TIMEOUT
 	DCGM_ST_TIMEOUT = -11
 	// DCGM_ST_VER_MISMATCH is the value for ECC VER MISMATCH
@@ -190,8 +192,6 @@ const (
 	DCGM_ST_NVML_DRIVER_TIMEOUT = -57
 	// DCGM_ST_NVVS_NO_AVAILABLE_TEST is the value for ECC NVVS NO AVAILABLE TEST
 	DCGM_ST_NVVS_NO_AVAILABLE_TEST = -58
-	// DCGM_ST_UNINITIALIZED is the value for DCGM not initialized
-	DCGM_ST_UNINITIALIZED = -59
 	// DCGM_ST_NO_NVVS is the value for NVVS not available
 	DCGM_ST_NO_NVVS = -60
 	// DCGM_ST_NVVS_NOT_RUNNING is the value for NVVS not running

--- a/pkg/dcgm/const_test.go
+++ b/pkg/dcgm/const_test.go
@@ -1,0 +1,67 @@
+package dcgm
+
+import (
+	"os"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+func TestSelectedStatusCodeConstantsMatchCHeader(t *testing.T) {
+	tests := []struct {
+		name string
+		got  int
+	}{
+		{"DCGM_ST_OK", DCGM_ST_OK},
+		{"DCGM_ST_BADPARAM", DCGM_ST_BADPARAM},
+		{"DCGM_ST_PENDING", DCGM_ST_PENDING},
+		{"DCGM_ST_UNINITIALIZED", DCGM_ST_UNINITIALIZED},
+		{"DCGM_ST_TIMEOUT", DCGM_ST_TIMEOUT},
+		{"DCGM_ST_VER_MISMATCH", DCGM_ST_VER_MISMATCH},
+		{"DCGM_ST_FUNCTION_NOT_FOUND", DCGM_ST_FUNCTION_NOT_FOUND},
+		{"DCGM_ST_CONNECTION_NOT_VALID", DCGM_ST_CONNECTION_NOT_VALID},
+		{"DCGM_ST_LIBRARY_NOT_FOUND", DCGM_ST_LIBRARY_NOT_FOUND},
+		{"DCGM_ST_INIT_ERROR", DCGM_ST_INIT_ERROR},
+		{"DCGM_ST_NVML_ERROR", DCGM_ST_NVML_ERROR},
+		{"DCGM_ST_NVML_NOT_LOADED", DCGM_ST_NVML_NOT_LOADED},
+	}
+
+	headerStatusCodes := dcgmStructsStatusCodes(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			want, ok := headerStatusCodes[tt.name]
+			if !ok {
+				t.Fatalf("%s was not found in dcgm_structs.h", tt.name)
+			}
+			if tt.got != want {
+				t.Fatalf("%s = %d, want %d", tt.name, tt.got, want)
+			}
+		})
+	}
+}
+
+func dcgmStructsStatusCodes(t *testing.T) map[string]int {
+	t.Helper()
+
+	content, err := os.ReadFile("dcgm_structs.h")
+	if err != nil {
+		t.Fatalf("read dcgm_structs.h: %v", err)
+	}
+
+	statusCodePattern := regexp.MustCompile(`(?m)^\s*(DCGM_ST_[A-Z0-9_]+)\s*=\s*(-?\d+),`)
+	matches := statusCodePattern.FindAllStringSubmatch(string(content), -1)
+	if len(matches) == 0 {
+		t.Fatal("no DCGM_ST_* status codes found in dcgm_structs.h")
+	}
+
+	statusCodes := make(map[string]int, len(matches))
+	for _, match := range matches {
+		value, err := strconv.Atoi(match[2])
+		if err != nil {
+			t.Fatalf("parse %s value %q: %v", match[1], match[2], err)
+		}
+		statusCodes[match[1]] = value
+	}
+
+	return statusCodes
+}


### PR DESCRIPTION
## Summary

  Fix `DCGM_ST_UNINITIALIZED` to match the DCGM C header.

  ## Changes

  - Correct `DCGM_ST_UNINITIALIZED` from `-59` to `-10`.
  - Add selected status-code parity test coverage against `pkg/dcgm/dcgm_structs.h`.

  ## Validation

  - `go test ./pkg/dcgm -run TestSelectedStatusCodeConstantsMatchCHeader -count=1 -v`
  - `go test ./pkg/dcgm -count=1`

  ## Notes

  `-59` is `DCGM_ST_MNDIAG_CONNECTION_NOT_AVAILABLE` in the DCGM header, so consumers comparing against the old go-dcgm `DCGM_ST_UNINITIALIZED` value could misclassify that status.
