### PR TITLE
fix(dcgm): harden Init/Shutdown refcount misuse

### DIFF
--- a/pkg/dcgm/api.go
+++ b/pkg/dcgm/api.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"sync"
 	"time"
 )
@@ -20,14 +19,13 @@ var (
 // - Embedded: Start hostengine within this process
 // - Standalone: Connect to an already running nv-hostengine
 // - StartHostengine: Start and connect to nv-hostengine, terminate before exiting
-// Returns a cleanup function and any error encountered
+// Returns a cleanup function on success. On error, cleanup is nil.
 func Init(m mode, args ...string) (cleanup func(), err error) {
 	mux.Lock()
 	defer mux.Unlock()
 
 	if dcgmInitCounter < 0 {
-		count := strconv.Itoa(dcgmInitCounter)
-		err = fmt.Errorf("shutdown() is called %s times, before init()", count[1:])
+		return nil, fmt.Errorf("shutdown() is called %d times, before init()", -dcgmInitCounter)
 	}
 
 	if dcgmInitCounter == 0 {
@@ -53,7 +51,7 @@ func Shutdown() (err error) {
 	defer mux.Unlock()
 
 	if dcgmInitCounter <= 0 {
-		err = errors.New("init() needs to be called before shutdown()")
+		return errors.New("init() needs to be called before shutdown()")
 	}
 
 	if dcgmInitCounter == 1 {

--- a/pkg/dcgm/api_test.go
+++ b/pkg/dcgm/api_test.go
@@ -17,10 +17,127 @@
 package dcgm
 
 import (
+	"os"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func setInitCounterForTest(t *testing.T, value int) {
+	t.Helper()
+
+	mux.Lock()
+	previous := dcgmInitCounter
+	dcgmInitCounter = value
+	mux.Unlock()
+
+	t.Cleanup(func() {
+		mux.Lock()
+		dcgmInitCounter = previous
+		mux.Unlock()
+	})
+	require.Equal(t, 0, previous, "test requires clean DCGM init counter")
+}
+
+func initCounterForTest() int {
+	mux.Lock()
+	defer mux.Unlock()
+
+	return dcgmInitCounter
+}
+
+func runWithDiscardedStderr(t *testing.T, f func()) {
+	t.Helper()
+
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, devNull.Close())
+	}()
+
+	stderr := os.Stderr
+	os.Stderr = devNull
+	defer func() {
+		os.Stderr = stderr
+	}()
+
+	f()
+}
+
+func TestInitWithNegativeCounterReturnsErrorWithoutCleanup(t *testing.T) {
+	setInitCounterForTest(t, -2)
+
+	cleanup, err := Init(Embedded)
+
+	require.Error(t, err)
+	require.Nil(t, cleanup)
+	require.Contains(t, err.Error(), "shutdown() is called 2 times, before init()")
+	require.Equal(t, -2, initCounterForTest())
+}
+
+func TestShutdownBeforeInitDoesNotCorruptCounter(t *testing.T) {
+	setInitCounterForTest(t, 0)
+
+	err := Shutdown()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "init() needs to be called before shutdown()")
+	require.Equal(t, 0, initCounterForTest())
+
+	err = Shutdown()
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "init() needs to be called before shutdown()")
+	require.Equal(t, 0, initCounterForTest())
+}
+
+func TestCleanupAfterManualShutdownDoesNotCorruptCounter(t *testing.T) {
+	require.Equal(t, 0, initCounterForTest(), "test requires clean DCGM init counter")
+
+	cleanup, err := Init(Embedded)
+	require.NoError(t, err)
+	require.NotNil(t, cleanup)
+	t.Cleanup(func() {
+		mux.Lock()
+		dcgmInitCounter = 0
+		mux.Unlock()
+	})
+
+	require.NoError(t, Shutdown())
+	require.Equal(t, 0, initCounterForTest())
+
+	runWithDiscardedStderr(t, cleanup)
+	require.Equal(t, 0, initCounterForTest())
+}
+
+func TestConcurrentShutdownBeforeInitDoesNotCorruptCounter(t *testing.T) {
+	setInitCounterForTest(t, 0)
+
+	const workers = 16
+	start := make(chan struct{})
+	errs := make(chan error, workers)
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			errs <- Shutdown()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "init() needs to be called before shutdown()")
+	}
+	require.Equal(t, 0, initCounterForTest())
+}
 
 func TestGetEntityGroupEntities(t *testing.T) {
 	withNvsdmMockConfig(t, "testdata/one_switch.yaml", func(t *testing.T) {


### PR DESCRIPTION
## Summary

  - Fix dcgm.Init so negative init-counter state returns nil, err without mutating the counter or returning cleanup.
  - Fix dcgm.Shutdown so calls before init return an error without decrementing the counter.
  - Add regression coverage for invalid shutdowns, negative init counter state, cleanup after manual shutdown, and concurrent invalid shutdown calls.

  ## Testing

  - go test ./pkg/dcgm -run 'Test(InitWithNegativeCounterReturnsErrorWithoutCleanup|ShutdownBeforeInitDoesNotCorruptCounter|CleanupAfterManualShutdownDoesNotCorruptCounter|
    ConcurrentShutdownBeforeInitDoesNotCorruptCounter)' -count=1 -v
  - go test ./pkg/dcgm -count=1 -v
  - go test ./tests -run TestDeviceCount -count=1 -v
  - go test -race ./tests -run TestDeviceCount -count=1 -v
  - go test -race ./pkg/dcgm -count=1 -v