### PR TITLE
Fix DCGM group cleanup on watch and health error paths

### DIFF
--- a/pkg/dcgm/fields.go
+++ b/pkg/dcgm/fields.go
@@ -127,6 +127,11 @@ func WatchFields(gpuID uint, fieldsGroup FieldHandle, groupName string) (groupId
 	if err != nil {
 		return groupId, err
 	}
+	defer func() {
+		if err != nil {
+			_ = DestroyGroup(group)
+		}
+	}()
 
 	err = AddToGroup(group, gpuID)
 	if err != nil {
@@ -139,7 +144,9 @@ func WatchFields(gpuID uint, fieldsGroup FieldHandle, groupName string) (groupId
 		return groupId, fmt.Errorf("error watching fields: %s", err)
 	}
 
-	_ = UpdateAllFields()
+	if err = updateAllFields(); err != nil {
+		return groupId, err
+	}
 	return group, nil
 }
 
@@ -390,6 +397,10 @@ func UpdateAllFields() error {
 
 	return errorString(result)
 }
+
+// updateAllFields is a test seam for forcing post-watch update failures.
+// Do not reassign it outside tests; tests that mutate it must not run in parallel.
+var updateAllFields = UpdateAllFields
 
 func toFieldValue(cfields []C.dcgmFieldValue_v1) []FieldValue_v1 {
 	fields := make([]FieldValue_v1, len(cfields))

--- a/pkg/dcgm/fields.go
+++ b/pkg/dcgm/fields.go
@@ -123,6 +123,10 @@ func FieldGroupDestroy(fieldsGroup FieldHandle) (err error) {
 // groupName is a name for the watch group.
 // Returns a group handle and any error encountered.
 func WatchFields(gpuID uint, fieldsGroup FieldHandle, groupName string) (groupId GroupHandle, err error) {
+	return watchFieldsWithUpdater(UpdateAllFields, gpuID, fieldsGroup, groupName)
+}
+
+func watchFieldsWithUpdater(update func() error, gpuID uint, fieldsGroup FieldHandle, groupName string) (groupId GroupHandle, err error) {
 	group, err := CreateGroup(groupName)
 	if err != nil {
 		return groupId, err
@@ -144,7 +148,7 @@ func WatchFields(gpuID uint, fieldsGroup FieldHandle, groupName string) (groupId
 		return groupId, fmt.Errorf("error watching fields: %s", err)
 	}
 
-	if err = updateAllFields(); err != nil {
+	if err = update(); err != nil {
 		return groupId, err
 	}
 	return group, nil
@@ -397,10 +401,6 @@ func UpdateAllFields() error {
 
 	return errorString(result)
 }
-
-// updateAllFields is a test seam for forcing post-watch update failures.
-// Do not reassign it outside tests; tests that mutate it must not run in parallel.
-var updateAllFields = UpdateAllFields
 
 func toFieldValue(cfields []C.dcgmFieldValue_v1) []FieldValue_v1 {
 	fields := make([]FieldValue_v1, len(cfields))

--- a/pkg/dcgm/group_lifecycle_test.go
+++ b/pkg/dcgm/group_lifecycle_test.go
@@ -1,0 +1,197 @@
+//go:build linux && cgo
+
+package dcgm
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func requireNoGroupCapErrorForTest(t *testing.T, iter int, err error) {
+	t.Helper()
+	require.Error(t, err)
+
+	require.Falsef(t,
+		isGroupCapErrorForTest(err),
+		"iter %d: group leak detected; CreateGroup hit DCGM_MAX_NUM_GROUPS: %v", iter, err)
+}
+
+func isGroupCapErrorForTest(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "max limit") || strings.Contains(msg, "max number of groups") ||
+		strings.Contains(msg, "max group")
+}
+
+func skipIfPidWatchRequiresRoot(t *testing.T, err error) {
+	t.Helper()
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "non-root") {
+		t.Skipf("PID field watches require root on this DCGM host: %v", err)
+	}
+}
+
+func TestGroupCapErrorMatcherRecognizesDCGMMaxLimit(t *testing.T) {
+	require.True(t, isGroupCapErrorForTest(errors.New("Max limit reached for the object")))
+	require.True(t, isGroupCapErrorForTest(errors.New("Add Group: Max number of groups already configured")))
+	require.False(t, isGroupCapErrorForTest(errors.New("This GPU is not supported by DCGM")))
+}
+
+func TestHealthCheckByGpuIdDoesNotLeakGroupOnError(t *testing.T) {
+	teardownTest := setupTest(t)
+	defer teardownTest(t)
+	runOnlyWithLiveGPUs(t)
+
+	const invalidGPU uint = 1 << 30
+	for i := 0; i < 70; i++ {
+		_, err := healthCheckByGpuId(invalidGPU)
+		requireNoGroupCapErrorForTest(t, i, err)
+	}
+}
+
+func TestWatchFieldsDoesNotLeakGroupOnError(t *testing.T) {
+	teardownTest := setupTest(t)
+	defer teardownTest(t)
+	runOnlyWithLiveGPUs(t)
+
+	fieldGroup, err := FieldGroupCreate("watch-fields-leak", []Short{DCGM_FI_DEV_GPU_TEMP})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, FieldGroupDestroy(fieldGroup))
+	}()
+
+	const invalidGPU uint = 1 << 30
+	for i := 0; i < 70; i++ {
+		_, err := WatchFields(invalidGPU, fieldGroup, "watch-fields-leak")
+		requireNoGroupCapErrorForTest(t, i, err)
+	}
+}
+
+func TestWatchPidFieldsDoesNotLeakGroupOnError(t *testing.T) {
+	teardownTest := setupTest(t)
+	defer teardownTest(t)
+	runOnlyWithLiveGPUs(t)
+
+	const invalidGPU uint = 1 << 30
+	for i := 0; i < 70; i++ {
+		_, err := watchPidFields(time.Microsecond*time.Duration(defaultUpdateFreq), time.Second*time.Duration(defaultMaxKeepAge), defaultMaxKeepSamples, invalidGPU)
+		requireNoGroupCapErrorForTest(t, i, err)
+	}
+}
+
+func TestWatchPidFieldsDoesNotLeakGroupOnNonRootWatchError(t *testing.T) {
+	teardownTest := setupTest(t)
+	defer teardownTest(t)
+	runOnlyWithLiveGPUs(t)
+
+	gpus, err := getSupportedDevices()
+	require.NoError(t, err)
+	require.NotEmpty(t, gpus)
+
+	// This regression is intentionally environment-specific: it covers
+	// dcgmWatchPidFields returning DCGM_ST_REQUIRES_ROOT on non-root hosts.
+	// Root hosts cover PID-watch success ownership in
+	// TestWatchPidFieldsDoesNotDestroyGroupOnSuccess.
+	for i := 0; i < 70; i++ {
+		group, err := watchPidFields(time.Microsecond*time.Duration(defaultUpdateFreq), time.Second*time.Duration(defaultMaxKeepAge), defaultMaxKeepSamples, gpus[0])
+		if err == nil {
+			require.NoError(t, DestroyGroup(group))
+			t.Skip("PID field watches succeeded; non-root watch-error cleanup path is not reproducible on this host")
+		}
+
+		requireNoGroupCapErrorForTest(t, i, err)
+
+		var dcgmErr *Error
+		require.ErrorAs(t, err, &dcgmErr)
+	}
+}
+
+func TestWatchFieldsDoesNotDestroyGroupOnSuccess(t *testing.T) {
+	teardownTest := setupTest(t)
+	defer teardownTest(t)
+	runOnlyWithLiveGPUs(t)
+
+	gpus, err := getSupportedDevices()
+	require.NoError(t, err)
+	require.NotEmpty(t, gpus)
+
+	fieldGroup, err := FieldGroupCreate("watch-fields-success", []Short{DCGM_FI_DEV_GPU_TEMP})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, FieldGroupDestroy(fieldGroup))
+	}()
+
+	group, err := WatchFields(gpus[0], fieldGroup, "watch-fields-success")
+	require.NoError(t, err)
+	require.NoError(t, DestroyGroup(group))
+}
+
+func TestWatchPidFieldsDoesNotDestroyGroupOnSuccess(t *testing.T) {
+	teardownTest := setupTest(t)
+	defer teardownTest(t)
+	runOnlyWithLiveGPUs(t)
+
+	gpus, err := getSupportedDevices()
+	require.NoError(t, err)
+	require.NotEmpty(t, gpus)
+
+	group, err := watchPidFields(time.Microsecond*time.Duration(defaultUpdateFreq), time.Second*time.Duration(defaultMaxKeepAge), defaultMaxKeepSamples, gpus[0])
+	skipIfPidWatchRequiresRoot(t, err)
+	require.NoError(t, err)
+	require.NoError(t, DestroyGroup(group))
+}
+
+func TestWatchFieldsReturnsUpdateAllFieldsErrorAndDestroysGroup(t *testing.T) {
+	teardownTest := setupTest(t)
+	defer teardownTest(t)
+	runOnlyWithLiveGPUs(t)
+
+	gpus, err := getSupportedDevices()
+	require.NoError(t, err)
+	require.NotEmpty(t, gpus)
+
+	fieldGroup, err := FieldGroupCreate("watch-fields-update-fail", []Short{DCGM_FI_DEV_XID_ERRORS})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, FieldGroupDestroy(fieldGroup))
+	}()
+
+	updateErr := errors.New("forced update error")
+	oldUpdateAllFields := updateAllFields
+	updateAllFields = func() error { return updateErr }
+	t.Cleanup(func() { updateAllFields = oldUpdateAllFields })
+
+	for i := 0; i < 70; i++ {
+		_, err = WatchFields(gpus[0], fieldGroup, "watch-fields-update-fail")
+		requireNoGroupCapErrorForTest(t, i, err)
+		require.ErrorIs(t, err, updateErr)
+	}
+}
+
+func TestWatchPidFieldsReturnsUpdateAllFieldsErrorAndDestroysGroup(t *testing.T) {
+	teardownTest := setupTest(t)
+	defer teardownTest(t)
+	runOnlyWithLiveGPUs(t)
+
+	gpus, err := getSupportedDevices()
+	require.NoError(t, err)
+	require.NotEmpty(t, gpus)
+
+	updateErr := errors.New("forced update error")
+	oldUpdateAllFields := updateAllFields
+	updateAllFields = func() error { return updateErr }
+	t.Cleanup(func() { updateAllFields = oldUpdateAllFields })
+
+	for i := 0; i < 70; i++ {
+		_, err = watchPidFields(time.Microsecond*time.Duration(defaultUpdateFreq), time.Second*time.Duration(defaultMaxKeepAge), defaultMaxKeepSamples, gpus[0])
+		skipIfPidWatchRequiresRoot(t, err)
+		requireNoGroupCapErrorForTest(t, i, err)
+		require.ErrorIs(t, err, updateErr)
+	}
+}

--- a/pkg/dcgm/group_lifecycle_test.go
+++ b/pkg/dcgm/group_lifecycle_test.go
@@ -189,8 +189,13 @@ func TestWatchPidFieldsReturnsUpdateAllFieldsErrorAndDestroysGroup(t *testing.T)
 	t.Cleanup(func() { updateAllFields = oldUpdateAllFields })
 
 	for i := 0; i < 70; i++ {
-		_, err = watchPidFields(time.Microsecond*time.Duration(defaultUpdateFreq), time.Second*time.Duration(defaultMaxKeepAge), defaultMaxKeepSamples, gpus[0])
-		skipIfPidWatchRequiresRoot(t, err)
+		_, err = watchPidFieldsWithWatcher(
+			func(GroupHandle, time.Duration, time.Duration, int) error { return nil },
+			time.Microsecond*time.Duration(defaultUpdateFreq),
+			time.Second*time.Duration(defaultMaxKeepAge),
+			defaultMaxKeepSamples,
+			gpus[0],
+		)
 		requireNoGroupCapErrorForTest(t, i, err)
 		require.ErrorIs(t, err, updateErr)
 	}

--- a/pkg/dcgm/group_lifecycle_test.go
+++ b/pkg/dcgm/group_lifecycle_test.go
@@ -163,12 +163,14 @@ func TestWatchFieldsReturnsUpdateAllFieldsErrorAndDestroysGroup(t *testing.T) {
 	}()
 
 	updateErr := errors.New("forced update error")
-	oldUpdateAllFields := updateAllFields
-	updateAllFields = func() error { return updateErr }
-	t.Cleanup(func() { updateAllFields = oldUpdateAllFields })
 
 	for i := 0; i < 70; i++ {
-		_, err = WatchFields(gpus[0], fieldGroup, "watch-fields-update-fail")
+		_, err = watchFieldsWithUpdater(
+			func() error { return updateErr },
+			gpus[0],
+			fieldGroup,
+			"watch-fields-update-fail",
+		)
 		requireNoGroupCapErrorForTest(t, i, err)
 		require.ErrorIs(t, err, updateErr)
 	}
@@ -184,13 +186,11 @@ func TestWatchPidFieldsReturnsUpdateAllFieldsErrorAndDestroysGroup(t *testing.T)
 	require.NotEmpty(t, gpus)
 
 	updateErr := errors.New("forced update error")
-	oldUpdateAllFields := updateAllFields
-	updateAllFields = func() error { return updateErr }
-	t.Cleanup(func() { updateAllFields = oldUpdateAllFields })
 
 	for i := 0; i < 70; i++ {
 		_, err = watchPidFieldsWithWatcher(
 			func(GroupHandle, time.Duration, time.Duration, int) error { return nil },
+			func() error { return updateErr },
 			time.Microsecond*time.Duration(defaultUpdateFreq),
 			time.Second*time.Duration(defaultMaxKeepAge),
 			defaultMaxKeepSamples,

--- a/pkg/dcgm/health.go
+++ b/pkg/dcgm/health.go
@@ -145,6 +145,9 @@ func healthCheckByGpuId(gpuID uint) (deviceHealth DeviceHealth, err error) {
 	if err != nil {
 		return
 	}
+	defer func() {
+		_ = DestroyGroup(groupID)
+	}()
 
 	err = AddToGroup(groupID, gpuID)
 	if err != nil {
@@ -180,7 +183,6 @@ func healthCheckByGpuId(gpuID uint) (deviceHealth DeviceHealth, err error) {
 		Status:  status,
 		Watches: watches,
 	}
-	_ = DestroyGroup(groupID)
 	return
 }
 

--- a/pkg/dcgm/process_info.go
+++ b/pkg/dcgm/process_info.go
@@ -96,7 +96,13 @@ func WatchPidFieldsEx(updateFreq, maxKeepAge time.Duration, maxKeepSamples int, 
 	return watchPidFields(updateFreq, maxKeepAge, maxKeepSamples, gpus...)
 }
 
+type watchPidFieldsFunc func(GroupHandle, time.Duration, time.Duration, int) error
+
 func watchPidFields(updateFreq, maxKeepAge time.Duration, maxKeepSamples int, gpus ...uint) (groupId GroupHandle, err error) {
+	return watchPidFieldsWithWatcher(watchPidFieldsForGroup, updateFreq, maxKeepAge, maxKeepSamples, gpus...)
+}
+
+func watchPidFieldsWithWatcher(watch watchPidFieldsFunc, updateFreq, maxKeepAge time.Duration, maxKeepSamples int, gpus ...uint) (groupId GroupHandle, err error) {
 	groupName := fmt.Sprintf("watchPids%d", rand.Uint64())
 	group, err := CreateGroup(groupName)
 	if err != nil {
@@ -124,15 +130,22 @@ func watchPidFields(updateFreq, maxKeepAge time.Duration, maxKeepSamples int, gp
 		}
 	}
 
-	result := C.dcgmWatchPidFields(handle.handle, group.handle, C.longlong(updateFreq.Microseconds()), C.double(maxKeepAge.Seconds()), C.int(maxKeepSamples))
-
-	if err = errorString(result); err != nil {
-		return groupId, &Error{msg: C.GoString(C.errorString(result)), Code: result}
+	if err = watch(group, updateFreq, maxKeepAge, maxKeepSamples); err != nil {
+		return groupId, err
 	}
 	if err = updateAllFields(); err != nil {
 		return groupId, err
 	}
 	return group, nil
+}
+
+func watchPidFieldsForGroup(group GroupHandle, updateFreq, maxKeepAge time.Duration, maxKeepSamples int) error {
+	result := C.dcgmWatchPidFields(handle.handle, group.handle, C.longlong(updateFreq.Microseconds()), C.double(maxKeepAge.Seconds()), C.int(maxKeepSamples))
+
+	if err := errorString(result); err != nil {
+		return &Error{msg: C.GoString(C.errorString(result)), Code: result}
+	}
+	return nil
 }
 
 func getProcessInfo(groupID GroupHandle, pid uint) (processInfo []ProcessInfo, err error) {

--- a/pkg/dcgm/process_info.go
+++ b/pkg/dcgm/process_info.go
@@ -99,10 +99,10 @@ func WatchPidFieldsEx(updateFreq, maxKeepAge time.Duration, maxKeepSamples int, 
 type watchPidFieldsFunc func(GroupHandle, time.Duration, time.Duration, int) error
 
 func watchPidFields(updateFreq, maxKeepAge time.Duration, maxKeepSamples int, gpus ...uint) (groupId GroupHandle, err error) {
-	return watchPidFieldsWithWatcher(watchPidFieldsForGroup, updateFreq, maxKeepAge, maxKeepSamples, gpus...)
+	return watchPidFieldsWithWatcher(watchPidFieldsForGroup, UpdateAllFields, updateFreq, maxKeepAge, maxKeepSamples, gpus...)
 }
 
-func watchPidFieldsWithWatcher(watch watchPidFieldsFunc, updateFreq, maxKeepAge time.Duration, maxKeepSamples int, gpus ...uint) (groupId GroupHandle, err error) {
+func watchPidFieldsWithWatcher(watch watchPidFieldsFunc, update func() error, updateFreq, maxKeepAge time.Duration, maxKeepSamples int, gpus ...uint) (groupId GroupHandle, err error) {
 	groupName := fmt.Sprintf("watchPids%d", rand.Uint64())
 	group, err := CreateGroup(groupName)
 	if err != nil {
@@ -133,7 +133,7 @@ func watchPidFieldsWithWatcher(watch watchPidFieldsFunc, updateFreq, maxKeepAge 
 	if err = watch(group, updateFreq, maxKeepAge, maxKeepSamples); err != nil {
 		return groupId, err
 	}
-	if err = updateAllFields(); err != nil {
+	if err = update(); err != nil {
 		return groupId, err
 	}
 	return group, nil

--- a/pkg/dcgm/process_info.go
+++ b/pkg/dcgm/process_info.go
@@ -102,6 +102,12 @@ func watchPidFields(updateFreq, maxKeepAge time.Duration, maxKeepSamples int, gp
 	if err != nil {
 		return
 	}
+	defer func() {
+		if err != nil {
+			_ = DestroyGroup(group)
+		}
+	}()
+
 	numGpus := len(gpus)
 
 	if numGpus == 0 {
@@ -123,7 +129,9 @@ func watchPidFields(updateFreq, maxKeepAge time.Duration, maxKeepSamples int, gp
 	if err = errorString(result); err != nil {
 		return groupId, &Error{msg: C.GoString(C.errorString(result)), Code: result}
 	}
-	_ = UpdateAllFields()
+	if err = updateAllFields(); err != nil {
+		return groupId, err
+	}
 	return group, nil
 }
 

--- a/samples/restApi/handlers/dcgm.go
+++ b/samples/restApi/handlers/dcgm.go
@@ -138,6 +138,11 @@ func getProcessInfo(resp http.ResponseWriter, req *http.Request) (pInfo []dcgm.P
 
 		return
 	}
+	defer func() {
+		if err := dcgm.DestroyGroup(group); err != nil {
+			log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		}
+	}()
 
 	// wait for watches to be enabled
 	log.Printf("Enabling DCGM watches to start collecting process stats. This may take a few seconds....")

--- a/samples/restApi/handlers/dcgm.go
+++ b/samples/restApi/handlers/dcgm.go
@@ -123,7 +123,23 @@ func getHealth(resp http.ResponseWriter, req *http.Request) (health *dcgm.Device
 	return &h
 }
 
+type processInfoDeps struct {
+	watchPidFields func() (dcgm.GroupHandle, error)
+	getProcessInfo func(dcgm.GroupHandle, uint) ([]dcgm.ProcessInfo, error)
+	destroyGroup   func(dcgm.GroupHandle) error
+	sleep          func(time.Duration)
+}
+
 func getProcessInfo(resp http.ResponseWriter, req *http.Request) (pInfo []dcgm.ProcessInfo) {
+	return getProcessInfoWithDeps(resp, req, processInfoDeps{
+		watchPidFields: dcgm.WatchPidFields,
+		getProcessInfo: dcgm.GetProcessInfo,
+		destroyGroup:   dcgm.DestroyGroup,
+		sleep:          time.Sleep,
+	})
+}
+
+func getProcessInfoWithDeps(resp http.ResponseWriter, req *http.Request, deps processInfoDeps) (pInfo []dcgm.ProcessInfo) {
 	params := mux.Vars(req)
 
 	pid := getId(resp, req, params["pid"])
@@ -131,7 +147,7 @@ func getProcessInfo(resp http.ResponseWriter, req *http.Request) (pInfo []dcgm.P
 		return
 	}
 
-	group, err := dcgm.WatchPidFields()
+	group, err := deps.watchPidFields()
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
 		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
@@ -139,16 +155,16 @@ func getProcessInfo(resp http.ResponseWriter, req *http.Request) (pInfo []dcgm.P
 		return
 	}
 	defer func() {
-		if err := dcgm.DestroyGroup(group); err != nil {
+		if err := deps.destroyGroup(group); err != nil {
 			log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
 		}
 	}()
 
 	// wait for watches to be enabled
 	log.Printf("Enabling DCGM watches to start collecting process stats. This may take a few seconds....")
-	time.Sleep(3000 * time.Millisecond)
+	deps.sleep(3000 * time.Millisecond)
 
-	pInfo, err = dcgm.GetProcessInfo(group, pid)
+	pInfo, err = deps.getProcessInfo(group, pid)
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
 		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())

--- a/samples/restApi/handlers/dcgm_test.go
+++ b/samples/restApi/handlers/dcgm_test.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
+	"github.com/gorilla/mux"
+)
+
+func TestGetProcessInfoDestroysWatchedGroup(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/process/123", nil)
+	req = mux.SetURLVars(req, map[string]string{"pid": "123"})
+
+	destroyCalled := false
+	got := getProcessInfoWithDeps(httptest.NewRecorder(), req, processInfoDeps{
+		watchPidFields: func() (dcgm.GroupHandle, error) {
+			return dcgm.GroupHandle{}, nil
+		},
+		getProcessInfo: func(dcgm.GroupHandle, uint) ([]dcgm.ProcessInfo, error) {
+			return []dcgm.ProcessInfo{{PID: 123}}, nil
+		},
+		destroyGroup: func(dcgm.GroupHandle) error {
+			destroyCalled = true
+			return nil
+		},
+		sleep: func(time.Duration) {},
+	})
+
+	if !destroyCalled {
+		t.Fatal("expected DestroyGroup to be called")
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected one process info entry, got %d", len(got))
+	}
+	if got[0].PID != 123 {
+		t.Fatalf("expected process info for PID 123, got %d", got[0].PID)
+	}
+}
+
+func TestGetProcessInfoDestroysGroupWhenGetProcessInfoFails(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/process/123", nil)
+	req = mux.SetURLVars(req, map[string]string{"pid": "123"})
+	rr := httptest.NewRecorder()
+
+	destroyCalled := false
+	got := getProcessInfoWithDeps(rr, req, processInfoDeps{
+		watchPidFields: func() (dcgm.GroupHandle, error) {
+			return dcgm.GroupHandle{}, nil
+		},
+		getProcessInfo: func(dcgm.GroupHandle, uint) ([]dcgm.ProcessInfo, error) {
+			return nil, errors.New("forced GetProcessInfo failure")
+		},
+		destroyGroup: func(dcgm.GroupHandle) error {
+			destroyCalled = true
+			return nil
+		},
+		sleep: func(time.Duration) {},
+	})
+
+	if !destroyCalled {
+		t.Fatal("expected DestroyGroup to be called even when GetProcessInfo fails")
+	}
+	if got != nil {
+		t.Fatalf("expected nil process info on error, got %v", got)
+	}
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rr.Code)
+	}
+}
+
+func TestGetProcessInfoDoesNotDestroyGroupWhenWatchFails(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/process/123", nil)
+	req = mux.SetURLVars(req, map[string]string{"pid": "123"})
+	rr := httptest.NewRecorder()
+
+	destroyCalled := false
+	getProcessInfoWithDeps(rr, req, processInfoDeps{
+		watchPidFields: func() (dcgm.GroupHandle, error) {
+			return dcgm.GroupHandle{}, errors.New("forced WatchPidFields failure")
+		},
+		getProcessInfo: func(dcgm.GroupHandle, uint) ([]dcgm.ProcessInfo, error) {
+			t.Fatal("GetProcessInfo must not be called when watch fails")
+			return nil, nil
+		},
+		destroyGroup: func(dcgm.GroupHandle) error {
+			destroyCalled = true
+			return nil
+		},
+		sleep: func(time.Duration) {
+			t.Fatal("sleep must not be called when watch fails")
+		},
+	})
+
+	if destroyCalled {
+		t.Fatal("DestroyGroup must not be called when WatchPidFields returned no group")
+	}
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", rr.Code)
+	}
+}

--- a/tests/processinfo_test.go
+++ b/tests/processinfo_test.go
@@ -1,12 +1,22 @@
 package tests
 
 import (
+	"errors"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
 )
+
+func skipIfPidWatchRequiresRoot(t *testing.T, err error) {
+	t.Helper()
+
+	var dcgmErr *dcgm.Error
+	if errors.As(err, &dcgmErr) && int(dcgmErr.Code) == dcgm.DCGM_ST_REQUIRES_ROOT {
+		t.Skipf("PID field watches require root on this DCGM host: %v", err)
+	}
+}
 
 // TestProcessInfo demonstrates getting process information for GPU processes
 // This is equivalent to the processInfo sample
@@ -20,6 +30,7 @@ func TestProcessInfo(t *testing.T) {
 	// Request DCGM to start recording stats for GPU process fields
 	group, err := dcgm.WatchPidFields()
 	if err != nil {
+		skipIfPidWatchRequiresRoot(t, err)
 		t.Fatalf("Failed to watch PID fields: %v", err)
 	}
 
@@ -73,6 +84,7 @@ func TestProcessInfoWithSpecificPID(t *testing.T) {
 	// Request DCGM to start recording stats for GPU process fields
 	group, err := dcgm.WatchPidFields()
 	if err != nil {
+		skipIfPidWatchRequiresRoot(t, err)
 		t.Fatalf("Failed to watch PID fields: %v", err)
 	}
 
@@ -102,6 +114,7 @@ func TestWatchPidFields(t *testing.T) {
 	// Test WatchPidFields function
 	group, err := dcgm.WatchPidFields()
 	if err != nil {
+		skipIfPidWatchRequiresRoot(t, err)
 		t.Fatalf("Failed to watch PID fields: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

  Fixes DCGM group lifecycle issues:

  - DCGM-6901: destroy health-check groups on error from `healthCheckByGpuId`.
  - DCGM-6902: destroy PID-watch groups on error from `watchPidFields`.
  - DCGM-6903: destroy field-watch groups on error from `WatchFields`.
  - DCGM-6917: return `UpdateAllFields` errors from `WatchFields` and `watchPidFields`, matching `WatchFieldsWithGroupEx`.
  - DCGM-6921: destroy the REST sample PID-watch group after `getProcessInfo`.

  The watch helpers now clean up only on failure and preserve group ownership on success. PID-watch DCGM errors still return `*dcgm.Error`, and the conditional `getSupportedDevices()` path is unchanged.

  ## Tests

  - `go test ./pkg/dcgm -run 'Test(GroupCapErrorMatcher|HealthCheckByGpuIdDoesNotLeakGroupOnError|WatchFieldsDoesNotLeakGroupOnError|WatchPidFieldsDoesNotLeakGroupOnError|
  WatchPidFieldsDoesNotLeakGroupOnNonRootWatchError|WatchFieldsDoesNotDestroyGroupOnSuccess|WatchPidFieldsDoesNotDestroyGroupOnSuccess|WatchFieldsReturnsUpdateAllFieldsErrorAndDestroysGroup|
  WatchPidFieldsReturnsUpdateAllFieldsErrorAndDestroysGroup)' -count=1 -v`
  - `go test ./samples/restApi/... -count=1`