### PR TITLE
samples/restApi: pre-parse templates (gosec G708 hardening)

### DIFF
--- a/samples/restApi/handlers/byIds.go
+++ b/samples/restApi/handlers/byIds.go
@@ -17,7 +17,7 @@ func DeviceInfo(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	printer(resp, req, device, deviceInfo)
+	printer(resp, req, device, deviceInfoTmpl)
 }
 
 // DeviceStatus handles HTTP requests for device status by device ID
@@ -33,7 +33,7 @@ func DeviceStatus(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	printer(resp, req, st, deviceStatus)
+	printer(resp, req, st, deviceStatusTmpl)
 }
 
 // ProcessInfo handles HTTP requests for process information by PID
@@ -65,7 +65,7 @@ func Health(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	printer(resp, req, h, healthStatus)
+	printer(resp, req, h, healthStatusTmpl)
 }
 
 // Status handles HTTP requests for DCGM daemon status
@@ -81,5 +81,5 @@ func Status(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	printer(resp, req, st, hostengine)
+	printer(resp, req, st, hostengineTmpl)
 }

--- a/samples/restApi/handlers/byUuids.go
+++ b/samples/restApi/handlers/byUuids.go
@@ -21,7 +21,7 @@ func DevicesUuids() {
 		return
 	}
 
-	for i := uint(0); i < count; i++ {
+	for i := range count {
 		deviceInfo, err := dcgm.GetDeviceInfo(i)
 		if err != nil {
 			log.Printf("(DCGM) Error getting device information: %s", err)
@@ -45,7 +45,7 @@ func DeviceInfoByUuid(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	printer(resp, req, device, deviceInfo)
+	printer(resp, req, device, deviceInfoTmpl)
 }
 
 // DeviceStatusByUuid handles HTTP requests for device status by GPU UUID
@@ -61,7 +61,7 @@ func DeviceStatusByUuid(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	printer(resp, req, st, deviceStatus)
+	printer(resp, req, st, deviceStatusTmpl)
 }
 
 // HealthByUuid handles HTTP requests for device health status by GPU UUID
@@ -77,5 +77,5 @@ func HealthByUuid(resp http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	printer(resp, req, h, healthStatus)
+	printer(resp, req, h, healthStatusTmpl)
 }

--- a/samples/restApi/handlers/utils.go
+++ b/samples/restApi/handlers/utils.go
@@ -95,6 +95,18 @@ CPU(%)          : {{printf "%.2f" .CPU}}
 `
 )
 
+// Pre-parsed templates. Parsing happens once at package init from the const
+// strings above; printer() and processPrint() consume the *template.Template
+// directly, which closes gosec G708 (template injection) by making the type
+// system reject free-form strings as a template source.
+var (
+	deviceInfoTmpl   = template.Must(template.New("DeviceInfo").Parse(deviceInfo))
+	deviceStatusTmpl = template.Must(template.New("DeviceStatus").Parse(deviceStatus))
+	processInfoTmpl  = template.Must(template.New("ProcessInfo").Parse(processInfo))
+	healthStatusTmpl = template.Must(template.New("HealthStatus").Parse(healthStatus))
+	hostengineTmpl   = template.Must(template.New("HostEngine").Parse(hostengine))
+)
+
 // getId converts a string key to a GPU ID
 // Returns math.MaxUint32 if the conversion fails
 func getId(resp http.ResponseWriter, req *http.Request, key string) uint {
@@ -173,10 +185,11 @@ func isJson(req *http.Request) bool {
 	return url[len(url)-4:] == "json"
 }
 
-// print formats and writes templated text output to the response
-func printer(resp http.ResponseWriter, req *http.Request, stats any, templ string) {
-	t := template.Must(template.New("").Parse(templ))
-	if err := t.Execute(resp, stats); err != nil {
+// printer formats and writes templated text output to the response.
+// The template is supplied as a pre-parsed *template.Template so the parse
+// step cannot accept attacker-controlled text (closes gosec G708).
+func printer(resp http.ResponseWriter, req *http.Request, stats any, tmpl *template.Template) {
+	if err := tmpl.Execute(resp, stats); err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
 		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
 	}
@@ -192,11 +205,11 @@ func encode(resp http.ResponseWriter, req *http.Request, stats any) {
 	}
 }
 
-// processPrint formats and writes process information to the response
+// processPrint formats and writes process information to the response using
+// the pre-parsed processInfoTmpl (closes gosec G708 for this call site).
 func processPrint(resp http.ResponseWriter, req *http.Request, pInfo []dcgm.ProcessInfo) {
-	t := template.Must(template.New("Process").Parse(processInfo))
 	for i := range pInfo {
-		if err := t.Execute(resp, pInfo[i]); err != nil {
+		if err := processInfoTmpl.Execute(resp, pInfo[i]); err != nil {
 			http.Error(resp, err.Error(), http.StatusInternalServerError)
 			log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
 

--- a/samples/restApi/handlers/utils_test.go
+++ b/samples/restApi/handlers/utils_test.go
@@ -1,0 +1,219 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/NVIDIA/go-dcgm/pkg/dcgm"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPrinter exercises every category of input across the package's
+// pre-parsed *template.Template values. Cases are tagged by category so
+// failures surface what kind of behavior regressed.
+func TestPrinter(t *testing.T) {
+	cases := []struct {
+		name       string
+		category   string // positive | negative | boundary | corner | attacker
+		tmpl       *template.Template
+		stats      any
+		wantCode   int
+		wantSubstr string // must appear in body
+		notSubstr  string // must NOT appear in body (proves no template re-evaluation)
+	}{
+		// positive — happy path; known-good stats render expected substring.
+		{
+			"positive_hostengine_renders_memory_and_cpu", "positive", hostengineTmpl,
+			dcgm.Status{Memory: 1024, CPU: 1.5},
+			http.StatusOK, "Memory(KB)      : 1024", "",
+		},
+		{
+			"positive_hostengine_renders_two_decimal_cpu", "positive", hostengineTmpl,
+			dcgm.Status{Memory: 1, CPU: 99.875},
+			http.StatusOK, "CPU(%)          : 99.88", "",
+		},
+		{
+			"positive_healthStatus_renders_overall", "positive", healthStatusTmpl,
+			dcgm.DeviceHealth{GPU: 0, Status: "OK"},
+			http.StatusOK, "Status             : OK", "",
+		},
+
+		// negative — template can't render the stats. Note: Execute() writes
+		// the static prefix before hitting the failing action, which
+		// implicitly commits HTTP 200 to the recorder. The subsequent
+		// http.Error() in printer() then appends the error message to the
+		// body but cannot rewrite the status code. We assert what actually
+		// happens (status stays 200, error text appears in body) — fixing
+		// the "should return 500" wart is a separate change, out of scope
+		// for the G708 hardening.
+		{
+			"negative_unknown_field_appends_error_in_body", "negative", hostengineTmpl,
+			struct{ Unrelated string }{"x"},
+			http.StatusOK, "can't evaluate field Memory", "",
+		},
+
+		// boundary — empty/zero stats render zero values, no panic.
+		{
+			"boundary_empty_hostengine_renders_zeros", "boundary", hostengineTmpl,
+			dcgm.Status{},
+			http.StatusOK, "Memory(KB)      : 0", "",
+		},
+		{
+			"boundary_health_no_watches_renders_header_only", "boundary", healthStatusTmpl,
+			dcgm.DeviceHealth{GPU: 0, Status: "OK"},
+			http.StatusOK, "GPU                : 0", "",
+		},
+		{
+			"boundary_health_with_one_watch_renders_block", "boundary", healthStatusTmpl,
+			dcgm.DeviceHealth{
+				GPU:    1,
+				Status: "Warn",
+				Watches: []dcgm.SystemWatch{
+					{Type: "PCIe", Status: "Warn", Error: "link down"},
+				},
+			},
+			http.StatusOK, "Type               : PCIe", "",
+		},
+
+		// corner — unicode and very large stats fields render through as data.
+		{
+			"corner_unicode_in_status_field", "corner", healthStatusTmpl,
+			dcgm.DeviceHealth{GPU: 0, Status: "Stätüs—✓"},
+			http.StatusOK, "Stätüs—✓", "",
+		},
+		{
+			"corner_oversized_status_string", "corner", healthStatusTmpl,
+			dcgm.DeviceHealth{GPU: 0, Status: strings.Repeat("A", 10_000)},
+			http.StatusOK, strings.Repeat("A", 100), "",
+		},
+
+		// attacker — values that LOOK like template directives must be rendered
+		// as data, NOT executed. This is the core security assertion: pre-parsed
+		// templates do not re-parse the stats payload, so {{...}} embedded in
+		// data round-trips verbatim into the response body.
+		{
+			"attacker_action_in_status_is_literal_data", "attacker", healthStatusTmpl,
+			dcgm.DeviceHealth{GPU: 0, Status: "{{print 1337}}"},
+			http.StatusOK, "{{print 1337}}", "1337\n",
+		},
+		{
+			"attacker_pipeline_in_status_is_literal_data", "attacker", healthStatusTmpl,
+			dcgm.DeviceHealth{GPU: 0, Status: "{{ .Foo | call }}"},
+			http.StatusOK, "{{ .Foo | call }}", "",
+		},
+		{
+			"attacker_html_script_tag_passes_through_as_text", "attacker", healthStatusTmpl,
+			dcgm.DeviceHealth{GPU: 0, Status: "<script>alert(1)</script>"},
+			// text/template does not HTML-escape — the script tag travels through
+			// as plain text. The assertion is that it is NOT executed by the
+			// templating engine (no eval of the inner expression).
+			http.StatusOK, "<script>alert(1)</script>", "",
+		},
+		{
+			"attacker_watch_error_field_with_action_is_literal", "attacker", healthStatusTmpl,
+			dcgm.DeviceHealth{
+				GPU:    0,
+				Status: "OK",
+				Watches: []dcgm.SystemWatch{
+					{Type: "X", Status: "X", Error: `{{exec "whoami"}}`},
+				},
+			},
+			http.StatusOK, `{{exec "whoami"}}`, "uid=",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+
+			printer(rec, req, c.stats, c.tmpl)
+
+			assert.Equal(t, c.wantCode, rec.Code, c.category+": status code")
+			if c.wantSubstr != "" {
+				assert.Contains(t, rec.Body.String(), c.wantSubstr,
+					c.category+": expected substring missing")
+			}
+			if c.notSubstr != "" {
+				assert.NotContains(t, rec.Body.String(), c.notSubstr,
+					c.category+": stats data must NOT be re-evaluated as template")
+			}
+		})
+	}
+}
+
+// TestProcessPrint mirrors TestPrinter but for the slice-driven processPrint
+// helper, which iterates and renders processInfoTmpl per element.
+func TestProcessPrint(t *testing.T) {
+	cases := []struct {
+		name       string
+		category   string
+		stats      []dcgm.ProcessInfo
+		wantCode   int
+		wantSubstr string
+		notSubstr  string
+	}{
+		// positive — single process renders identifying fields.
+		{
+			"positive_single_process_renders_pid_and_gpu", "positive",
+			[]dcgm.ProcessInfo{{GPU: 0, PID: 42, Name: "nvidia-smi"}},
+			http.StatusOK, "PID                          : 42", "",
+		},
+
+		// negative — empty slice produces empty body, status stays 200
+		// (the handler short-circuits before reaching processPrint in real flow;
+		// here we exercise the helper directly).
+		{
+			"negative_nil_slice_no_writes", "negative",
+			nil,
+			http.StatusOK, "", "GPU ID",
+		},
+
+		// boundary — multiple processes render multiple blocks.
+		{
+			"boundary_two_processes_render_both", "boundary",
+			[]dcgm.ProcessInfo{
+				{GPU: 0, PID: 1, Name: "a"},
+				{GPU: 0, PID: 2, Name: "b"},
+			},
+			http.StatusOK, "PID                          : 2", "",
+		},
+
+		// corner — unicode in process name.
+		{
+			"corner_unicode_in_process_name", "corner",
+			[]dcgm.ProcessInfo{{GPU: 0, PID: 1, Name: "進程"}},
+			http.StatusOK, "進程", "",
+		},
+
+		// attacker — template-action lookalike in the Name field must not be
+		// re-evaluated by the pre-parsed processInfoTmpl.
+		{
+			"attacker_action_in_name_is_literal_data", "attacker",
+			[]dcgm.ProcessInfo{{GPU: 0, PID: 1, Name: "{{print 9000}}"}},
+			http.StatusOK, "{{print 9000}}", "9000\n",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+
+			processPrint(rec, req, c.stats)
+
+			assert.Equal(t, c.wantCode, rec.Code, c.category+": status code")
+			if c.wantSubstr != "" {
+				assert.Contains(t, rec.Body.String(), c.wantSubstr,
+					c.category+": expected substring missing")
+			}
+			if c.notSubstr != "" {
+				assert.NotContains(t, rec.Body.String(), c.notSubstr,
+					c.category+": stats data must NOT be re-evaluated as template")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Hi 👋

We were running some static analysis over a fork of this repo (golangci-lint + gosec, tier-1 config) and gosec flagged a couple of **G708 (server-side template injection)** HIGH-severity findings in `samples/restApi/handlers/utils.go`:

```
samples/restApi/handlers/utils.go:179  G708 (CWE-94)  printer()
samples/restApi/handlers/utils.go:199  G708 (CWE-94)  processPrint()
```

The flagged statements parse a `text/template` from a value that gosec's taint analysis treats as attacker-reachable:

```go
func printer(resp http.ResponseWriter, req *http.Request, stats any, templ string) {
    t := template.Must(template.New("").Parse(templ))  // <-- G708
    ...
}
```

Today **every caller passes a package-level `const` string**, so this is fragile-by-structure rather than unsafe-today. But sample code tends to get copy-pasted into production, and the next reader who wires HTTP form input into `templ` gets RCE. The fix is purely structural.

## What this PR does

- Pre-parses every template once at package init into a package-level `*template.Template` (`deviceInfoTmpl`, `processInfoTmpl`, etc.).
- Tightens `printer`'s signature from `templ string` to `tmpl *template.Template`. The function can no longer accept a free-form string, so the taint source is closed at the type-system level — the compiler will reject any future `printer(..., userInput)` call.
- Same treatment for `processPrint` (now uses `processInfoTmpl`).
- Updates the 7 `printer` call sites in `byIds.go` and `byUuids.go` to pass the pre-parsed templates.

Templates stay `text/template` (the samples render plain-text curl-style output, not HTML) — no escaping behavior changes.

## TDD + table-driven tests

Added `samples/restApi/handlers/utils_test.go` (18 cases across two table-driven tests) covering five categories per the test struct's `category` tag:

| Category | What it asserts |
|---|---|
| `positive` | Known-good stats render expected substrings |
| `negative` | Templates that can't render the stats produce a logged error |
| `boundary` | Zero/empty stats, single-element collections, no panic |
| `corner` | Unicode, oversized strings |
| `attacker` | `{{ ... }}` template syntax embedded in stats data renders as **data**, NOT re-evaluated as a template — this is the core security assertion that the pre-parsed template doesn't re-parse the payload |

Tests are GPU-less (`httptest.NewRecorder` only, no `dcgm.Init`), so they run on any CI runner. House style follows `pkg/dcgm/diag_test.go`: `stretchr/testify/assert` + `t.Run(tt.name, ...)` subtests.

## Why this is low risk

- No public API change (all touched identifiers are package-private).
- No behavior change for any current caller — every existing call site was already passing a constant.
- All 9 sample binaries build cleanly (`go build ./samples/...`).
- `go vet`, `gofmt`, and the new `go test ./samples/restApi/handlers/...` all green.
- Drive-by: `DevicesUuids()` loop modernized from `for i := uint(0); i < count; i++` to `for i := range count` (Go 1.22+ rangeint, since go.mod is `go 1.23`). Happy to split this out if you'd prefer a single-concern PR.

Cheers, and thanks for go-dcgm — it's been a great library to work with.

## Test plan

- [x] `go build ./samples/restApi/...`
- [x] `go test -v -count=1 ./samples/restApi/handlers/...` — 18/18 pass
- [x] `go vet ./samples/restApi/...`
- [x] `gofmt -l samples/restApi/handlers/` — empty
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)