### PR TITLE
samples/restApi: sanitize caller-controlled log fields (G706)

### DIFF
--- a/samples/restApi/handlers/dcgm.go
+++ b/samples/restApi/handlers/dcgm.go
@@ -15,7 +15,7 @@ func getStatus(resp http.ResponseWriter, req *http.Request) (status *dcgm.Status
 	st, err := dcgm.Introspect()
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 
 		return
 	}
@@ -47,7 +47,7 @@ func getDeviceInfo(resp http.ResponseWriter, req *http.Request) (device *dcgm.De
 	d, err := dcgm.GetDeviceInfo(id)
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 
 		return
 	}
@@ -83,7 +83,7 @@ func getDeviceStatus(resp http.ResponseWriter, req *http.Request) (status *dcgm.
 	st, err := dcgm.GetDeviceStatus(id)
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 
 		return
 	}
@@ -115,7 +115,7 @@ func getHealth(resp http.ResponseWriter, req *http.Request) (health *dcgm.Device
 	h, err := dcgm.HealthCheckByGpuId(id)
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 
 		return
 	}
@@ -134,7 +134,7 @@ func getProcessInfo(resp http.ResponseWriter, req *http.Request) (pInfo []dcgm.P
 	group, err := dcgm.WatchPidFields()
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 
 		return
 	}
@@ -146,7 +146,7 @@ func getProcessInfo(resp http.ResponseWriter, req *http.Request) (pInfo []dcgm.P
 	pInfo, err = dcgm.GetProcessInfo(group, pid)
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 	}
 
 	return

--- a/samples/restApi/handlers/utils.go
+++ b/samples/restApi/handlers/utils.go
@@ -95,13 +95,28 @@ CPU(%)          : {{printf "%.2f" .CPU}}
 `
 )
 
+// logRequestError emits a log line tagged with the inbound request's Host
+// and URL plus a descriptive message. Caller-controlled fields (Host, URL,
+// msg) are formatted with %q so newlines, null bytes, ANSI escapes, and
+// other control characters are rendered as Go-quoted escape sequences
+// instead of being passed through verbatim. This closes gosec G706 (log
+// injection via taint analysis) and defends against an attacker forging
+// fake log entries by stuffing LF/CRLF into the Host header.
+func logRequestError(req *http.Request, msg string) {
+	var urlStr string
+	if req.URL != nil {
+		urlStr = req.URL.String()
+	}
+	log.Printf("error: host=%q url=%q msg=%q", req.Host, urlStr, msg)
+}
+
 // getId converts a string key to a GPU ID
 // Returns math.MaxUint32 if the conversion fails
 func getId(resp http.ResponseWriter, req *http.Request, key string) uint {
 	id, err := strconv.ParseUint(key, base, bitsize)
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusBadRequest)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 
 		return math.MaxUint32
 	}
@@ -113,7 +128,7 @@ func getIdByUuid(resp http.ResponseWriter, req *http.Request, key string) uint {
 	id, exists := uuids[key]
 	if !exists {
 		http.NotFound(resp, req)
-		log.Printf("error: %v%v:  %v (page not found)", req.Host, req.URL, http.StatusNotFound)
+		logRequestError(req, fmt.Sprintf("%d (page not found)", http.StatusNotFound))
 
 		return math.MaxUint32
 	}
@@ -127,14 +142,14 @@ func isValidId(id uint, resp http.ResponseWriter, req *http.Request) bool {
 	count, err := dcgm.GetAllDeviceCount()
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 
 		return false
 	}
 
 	if id >= count {
 		http.NotFound(resp, req)
-		log.Printf("error: %v%v: %v (page not found)", req.Host, req.URL, http.StatusNotFound)
+		logRequestError(req, fmt.Sprintf("%d (page not found)", http.StatusNotFound))
 
 		return false
 	}
@@ -148,7 +163,7 @@ func isDcgmSupported(gpuId uint, resp http.ResponseWriter, req *http.Request) bo
 	gpus, err := dcgm.GetSupportedDevices()
 	if err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 
 		return false
 	}
@@ -161,7 +176,7 @@ func isDcgmSupported(gpuId uint, resp http.ResponseWriter, req *http.Request) bo
 
 	err = fmt.Errorf("error adding gpu %d to group: This gpu is not supported by dcgm", gpuId)
 	http.Error(resp, err.Error(), http.StatusInternalServerError)
-	log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+	logRequestError(req, err.Error())
 
 	return false
 }
@@ -178,7 +193,7 @@ func printer(resp http.ResponseWriter, req *http.Request, stats any, templ strin
 	t := template.Must(template.New("").Parse(templ))
 	if err := t.Execute(resp, stats); err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 	}
 }
 
@@ -188,7 +203,7 @@ func encode(resp http.ResponseWriter, req *http.Request, stats any) {
 
 	if err := json.NewEncoder(resp).Encode(stats); err != nil {
 		http.Error(resp, err.Error(), http.StatusInternalServerError)
-		log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+		logRequestError(req, err.Error())
 	}
 }
 
@@ -198,7 +213,7 @@ func processPrint(resp http.ResponseWriter, req *http.Request, pInfo []dcgm.Proc
 	for i := range pInfo {
 		if err := t.Execute(resp, pInfo[i]); err != nil {
 			http.Error(resp, err.Error(), http.StatusInternalServerError)
-			log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
+			logRequestError(req, err.Error())
 
 			return
 		}

--- a/samples/restApi/handlers/utils_test.go
+++ b/samples/restApi/handlers/utils_test.go
@@ -1,0 +1,211 @@
+package handlers
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestLogRequestError pins the contract for the log-injection-safe error
+// log helper. Every case asserts the blanket invariant that no raw control
+// character (LF, CR, NUL, ESC) survives the helper into the final log line —
+// this is what closes gosec G706. Attacker cases drive in classic
+// log-forgery payloads (newline-injected fake log entries, CRLF, null-byte
+// truncation, BEL/backspace terminal abuse, ANSI clear-screen, Unicode line
+// separators).
+func TestLogRequestError(t *testing.T) {
+	cases := []struct {
+		name       string
+		category   string // positive | boundary | corner | attacker
+		host       string
+		urlPath    string
+		msg        string
+		wantSubstr []string // each must appear in the captured log line
+	}{
+		// positive — benign inputs render in quoted form, readable.
+		{
+			"positive_benign_request", "positive",
+			"example.com", "/devices/0", "bad gateway",
+			[]string{`host="example.com"`, `url="/devices/0"`, `msg="bad gateway"`},
+		},
+
+		// boundary — empty fields don't panic; quoted empty strings appear.
+		{
+			"boundary_empty_fields", "boundary",
+			"", "", "",
+			[]string{`host=""`, `url=""`, `msg=""`},
+		},
+
+		// corner — multibyte UTF-8 in legitimate input is preserved through %q
+		// (Go's %q keeps printable Unicode as-is, only escapes non-printables).
+		{
+			"corner_unicode_in_host", "corner",
+			"exämple.com", "/", "ok",
+			[]string{`exämple.com`},
+		},
+
+		// attacker — LF in Host: classic log-forgery via injected fake entry.
+		// %q must render the LF as the two-char escape \n.
+		{
+			"attacker_lf_in_host_forges_fake_entry", "attacker",
+			"evil.com\n2026-05-24 ATTACKER bypassed auth", "/", "ok",
+			[]string{`\n`, "ATTACKER bypassed auth"}, // escaped form survives as data
+		},
+
+		// attacker — CRLF: forges an HTTP-style header-looking line.
+		{
+			"attacker_crlf_in_msg", "attacker",
+			"evil", "/", "boom\r\nFAKE-HEADER: x",
+			[]string{`\r\n`, "FAKE-HEADER"},
+		},
+
+		// attacker — null byte: defeats parsers that null-terminate strings.
+		{
+			"attacker_null_byte_in_msg_does_not_truncate", "attacker",
+			"evil", "/", "before\x00after",
+			[]string{`\x00`, "after"},
+		},
+
+		// attacker — BEL (\a). Some terminal log viewers beep on this byte.
+		// Go's %q renders BEL as \a (Go-syntax escape).
+		{
+			"attacker_bel_in_msg", "attacker",
+			"evil", "/", "spam\a\a\a",
+			[]string{`\a`},
+		},
+
+		// attacker — backspace can erase preceding log content on terminals.
+		// Go's %q renders BS as \b.
+		{
+			"attacker_backspace_in_msg", "attacker",
+			"evil", "/", "log entry\b\b\bFAKE",
+			[]string{`\b`, "FAKE"},
+		},
+
+		// attacker — ESC sequence (\x1b[2J = ANSI clear-screen). Could wipe
+		// a developer's terminal mid-tail.
+		{
+			"attacker_ansi_clear_screen_in_msg", "attacker",
+			"evil", "/", "before\x1b[2Jafter",
+			[]string{`\x1b`, "after"},
+		},
+
+		// attacker — Unicode line/paragraph separators (U+2028, U+2029) are
+		// treated as line breaks by some log parsers / JSON.parse semantics.
+		// Go's %q renders them as   /  .
+		{
+			"attacker_unicode_line_separator_in_msg", "attacker",
+			"evil", "/", "before injected",
+			[]string{`\u2028`},
+		},
+		{
+			"attacker_unicode_paragraph_separator_in_host", "attacker",
+			"evil spoof", "/", "ok",
+			[]string{`\u2029`},
+		},
+
+		// attacker — embedded double quotes try to escape the quoted region.
+		// Go's %q backslash-escapes them.
+		{
+			"attacker_embedded_quote_in_msg", "attacker",
+			"evil", "/", `" host="trusted.example.com`,
+			[]string{`\"`}, // the embedded quote is escaped
+		},
+
+		// attacker — long string: must not crash, helper truncates nothing
+		// (caller could add their own length cap; the security property is
+		// just that it doesn't break log-line invariants).
+		{
+			"attacker_oversized_msg_does_not_break_invariants", "attacker",
+			"evil", "/", strings.Repeat("A", 10_000),
+			[]string{strings.Repeat("A", 100)},
+		},
+
+		// attacker — mixed payload: every category combined in one request.
+		// Note: CRLF intentionally goes in msg, not URL path. url.URL.String()
+		// percent-encodes control characters in Path (\r → %0D, \n → %0A) so
+		// the URL field is already cleaned before %q sees it; we exercise %q
+		// directly by routing the CRLF through msg.
+		{
+			"attacker_mixed_lf_crlf_null_esc_in_one_request", "attacker",
+			"a\nb", "/safe", "d\r\ne\x00f\x1bg",
+			[]string{`\n`, `\r\n`, `\x00`, `\x1b`},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// Capture log output. log.Default() is the global logger that
+			// every log.Printf call in handlers/ writes to.
+			var buf bytes.Buffer
+			origOut := log.Default().Writer()
+			origFlags := log.Default().Flags()
+			log.SetOutput(&buf)
+			log.SetFlags(0) // drop date/time prefix for cleaner assertion
+			t.Cleanup(func() {
+				log.SetOutput(origOut)
+				log.SetFlags(origFlags)
+			})
+
+			req := &http.Request{
+				Host: c.host,
+				URL:  &url.URL{Path: c.urlPath},
+			}
+
+			logRequestError(req, c.msg)
+
+			got := strings.TrimSuffix(buf.String(), "\n")
+
+			// Blanket security invariant: NO raw control character survives
+			// into the log line. This is what closes gosec G706 — an
+			// attacker cannot inject a synthetic log entry, terminal escape,
+			// null-byte truncation, etc., regardless of which field carried
+			// the payload.
+			for _, badByte := range []struct{ name, b string }{
+				{"LF", "\n"},
+				{"CR", "\r"},
+				{"NUL", "\x00"},
+				{"ESC", "\x1b"},
+				{"BEL", "\a"},
+				{"BS", "\b"},
+				{"U+2028", " "},
+				{"U+2029", " "},
+			} {
+				assert.False(t, strings.Contains(got, badByte.b),
+					c.category+": raw "+badByte.name+" must not survive into log line")
+			}
+
+			// Per-case substrings.
+			for _, s := range c.wantSubstr {
+				assert.Contains(t, got, s,
+					c.category+": expected substring %q in log line", s)
+			}
+		})
+	}
+}
+
+// TestLogRequestError_NilURL guards the defensive nil-URL path. Synthetic
+// or partially-initialized *http.Request values can have a nil URL pointer;
+// the helper must not panic.
+func TestLogRequestError_NilURL(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(log.LstdFlags)
+	})
+
+	req := &http.Request{Host: "host", URL: nil}
+	assert.NotPanics(t, func() {
+		logRequestError(req, "msg")
+	})
+	got := strings.TrimSuffix(buf.String(), "\n")
+	assert.Contains(t, got, `url=""`, "nil URL renders as empty quoted string")
+}


### PR DESCRIPTION
## Hi 👋

Same static-analysis run as #124 — gosec also flagged **G706 (log injection via taint analysis)** at 15 sites across `samples/restApi/handlers/{utils,dcgm}.go`. All instances are this pattern:

```go
log.Printf("error: %v%v: %v", req.Host, req.URL, err.Error())
```

`req.Host` is set from the `Host:` header, so a client can stuff `\n`, `\r\n`, `\x00`, ANSI escapes, etc. into it and forge log entries or abuse terminal log tails. Sample code → likely to be copy-pasted → worth fixing.

## What this PR does

Adds a tiny helper in `handlers/utils.go`:

```go
func logRequestError(req *http.Request, msg string) {
    var urlStr string
    if req.URL != nil {
        urlStr = req.URL.String()
    }
    log.Printf("error: host=%q url=%q msg=%q", req.Host, urlStr, msg)
}
```

`%q` is gosec's recognized taint-cleanser — Go renders LF/CR as `\n`/`\r`, NUL as `\x00`, ANSI ESC as `\x1b`, U+2028/U+2029 as ` `/` `, and backslash-escapes embedded quotes. No raw control character survives into the log line regardless of which field carried the payload.

All 15 G706 sites in `utils.go` (9) and `dcgm.go` (6) now call the helper.

## TDD + table-driven tests with nasty cases

Added `samples/restApi/handlers/utils_test.go` (15-case `TestLogRequestError` + 1 `TestLogRequestError_NilURL`). Categories:

| Category | Cases | What it covers |
|---|---|---|
| positive | 1 | Benign request renders quoted, readable |
| boundary | 1 | Empty fields don't panic |
| corner | 1 | Multibyte UTF-8 passes through readable |
| attacker | 12 | LF, CRLF, NUL, BEL, BS, ANSI ESC `\x1b[2J`, U+2028, U+2029, embedded quote, 10 KB string, and a mixed-all-attacks case |

Every case enforces a blanket security invariant via a loop over `{LF, CR, NUL, ESC, BEL, BS, U+2028, U+2029}` — none of those raw bytes may appear anywhere in the captured log line. Tests are GPU-less (`log.SetOutput(&buf)` + synthetic `*http.Request`).

## Heads-up on log line format

The format changes from `error: <host><url>: <msg>` (which had no separator between Host and URL — a small wart) to `error: host="..." url="..." msg="..."`. More grep-friendly, but if anything downstream is structurally parsing these sample logs I can do a tighter `%v`→`%q` swap that preserves the wire format. Happy to switch.

## Why this is low risk

- Helper is package-private, no public API change.
- Sample-only — no `pkg/` code touched.
- All 9 sample binaries build cleanly (`go build ./samples/...`).
- `go vet`, `gofmt`, and the 16 new tests all green.

## Test plan

- [x] `go build ./samples/restApi/...`
- [x] `go test -v -count=1 ./samples/restApi/handlers/...` — 16/16 pass
- [x] `go vet ./samples/restApi/...`
- [x] `gofmt -l samples/restApi/handlers/` — empty
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)