### PR TITLE
feat(vsock): DCGM-5059 Add VSOCK standalone routing via dcgmConnect_v3

### DIFF
--- a/pkg/dcgm/admin.go
+++ b/pkg/dcgm/admin.go
@@ -33,6 +33,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -124,28 +125,67 @@ func stopEmbedded() (err error) {
 	return
 }
 
+type standaloneConnection struct {
+	address    string
+	socketFlag string
+	useV3      bool
+}
+
+func standaloneConnectionArgs(args ...string) (standaloneConnection, error) {
+	if len(args) > 0 && isDCGMConnectionString(args[0]) {
+		return standaloneConnection{address: args[0], useV3: true}, nil
+	}
+	if len(args) < 2 {
+		return standaloneConnection{}, errors.New("missing dcgm address and / or port")
+	}
+	return standaloneConnection{address: args[0], socketFlag: args[1]}, nil
+}
+
+func isDCGMConnectionString(address string) bool {
+	lower := strings.ToLower(address)
+	return strings.HasPrefix(lower, "tcp://") ||
+		strings.HasPrefix(lower, "unix://") ||
+		strings.HasPrefix(lower, "vsock://")
+}
+
+func dcgmSymbolAvailable(symbol string) bool {
+	if dcgmLibHandle == nil {
+		return false
+	}
+	cSymbol := C.CString(symbol)
+	defer freeCString(cSymbol)
+	return C.dlsym(dcgmLibHandle, cSymbol) != nil
+}
+
 func connectStandalone(args ...string) (err error) {
+	conn, err := standaloneConnectionArgs(args...)
+	if err != nil {
+		return err
+	}
+	if conn.useV3 {
+		return connectStandaloneV3(conn.address)
+	}
+	return connectStandaloneV2(conn.address, conn.socketFlag)
+}
+
+func connectStandaloneV2(address, socketFlag string) (err error) {
 	var (
 		cHandle       C.dcgmHandle_t
 		connectParams C.dcgmConnectV2Params_v2
 	)
-
-	if len(args) < 2 {
-		return errors.New("missing dcgm address and / or port")
-	}
 
 	result := C.dcgmInit()
 	if err = errorString(result); err != nil {
 		return fmt.Errorf("error initializing DCGM: %s", err)
 	}
 
-	addr := C.CString(args[0])
+	addr := C.CString(address)
 	defer freeCString(addr)
 	connectParams.version = makeVersion2(unsafe.Sizeof(connectParams))
 
-	sck, err := strconv.ParseUint(args[1], 10, 32)
+	sck, err := strconv.ParseUint(socketFlag, 10, 32)
 	if err != nil {
-		return fmt.Errorf("error parsing %s: %v", args[1], err)
+		return fmt.Errorf("error parsing %s: %v", socketFlag, err)
 	}
 	connectParams.addressIsUnixSocket = C.uint(sck)
 
@@ -155,8 +195,36 @@ func connectStandalone(args ...string) (err error) {
 	}
 
 	handle = dcgmHandle{cHandle}
+	return nil
+}
 
-	return
+func connectStandaloneV3(connectionString string) (err error) {
+	const dcgmConnectV3Symbol = "dcgmConnect_v3"
+	if !dcgmSymbolAvailable(dcgmConnectV3Symbol) {
+		return fmt.Errorf("%s is not available in libdcgm.so.4; DCGM connection strings require DCGM 4.5.0 or newer", dcgmConnectV3Symbol)
+	}
+
+	var (
+		cHandle       C.dcgmHandle_t
+		connectParams C.dcgmConnectV3Params_v1
+	)
+
+	result := C.dcgmInit()
+	if err = errorString(result); err != nil {
+		return fmt.Errorf("error initializing DCGM: %s", err)
+	}
+
+	cConnectionString := C.CString(connectionString)
+	defer freeCString(cConnectionString)
+	connectParams.version = makeVersion1(unsafe.Sizeof(connectParams))
+
+	result = C.dcgmConnect_v3(cConnectionString, &connectParams, &cHandle)
+	if err = errorString(result); err != nil {
+		return fmt.Errorf("error connecting to nv-hostengine: %s", err)
+	}
+
+	handle = dcgmHandle{cHandle}
+	return nil
 }
 
 func disconnectStandalone() (err error) {

--- a/pkg/dcgm/admin_test.go
+++ b/pkg/dcgm/admin_test.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dcgm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStandaloneConnectionArgsUsesV3ForSupportedConnectionStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "vsock one arg", args: []string{"vsock://3:5555"}},
+		{name: "vsock legacy socket flag ignored", args: []string{"vsock://3:5555", "0"}},
+		{name: "uppercase vsock legacy socket flag ignored", args: []string{"VSOCK://3:5555", "0"}},
+		{name: "tcp uri legacy socket flag ignored", args: []string{"tcp://127.0.0.1:5555", "0"}},
+		{name: "uppercase tcp uri legacy socket flag ignored", args: []string{"TCP://127.0.0.1:5555", "0"}},
+		{name: "unix uri legacy socket flag ignored", args: []string{"unix:///tmp/nv-hostengine", "1"}},
+		{name: "uppercase unix uri legacy socket flag ignored", args: []string{"UNIX:///tmp/nv-hostengine", "1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := standaloneConnectionArgs(tt.args...)
+			require.NoError(t, err)
+			require.True(t, got.useV3)
+			require.Equal(t, tt.args[0], got.address)
+			require.Empty(t, got.socketFlag)
+		})
+	}
+}
+
+func TestStandaloneConnectionArgsPreservesLegacyV2Arguments(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "host port", args: []string{"127.0.0.1:5555", "0"}},
+		{name: "bracketed ipv6 host port", args: []string{"[::1]:5555", "0"}},
+		{name: "unix socket legacy flag", args: []string{"/tmp/nv-hostengine", "1"}},
+		{name: "unsupported http uri with legacy socket flag", args: []string{"http://127.0.0.1:5555", "0"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := standaloneConnectionArgs(tt.args...)
+			require.NoError(t, err)
+			require.False(t, got.useV3)
+			require.Equal(t, tt.args[0], got.address)
+			require.Equal(t, tt.args[1], got.socketFlag)
+		})
+	}
+}
+
+func TestStandaloneConnectionArgsRejectsLegacyMissingSocketFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "no args", args: nil},
+		{name: "raw host without socket flag", args: []string{"127.0.0.1:5555"}},
+		{name: "unsupported http uri without socket flag", args: []string{"http://127.0.0.1:5555"}},
+		{name: "unsupported https uri without socket flag", args: []string{"https://127.0.0.1:5555"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := standaloneConnectionArgs(tt.args...)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "missing dcgm address and / or port")
+		})
+	}
+}
+
+func TestConnectStandaloneV3ReturnsErrorWhenSymbolUnavailable(t *testing.T) {
+	oldLibHandle := dcgmLibHandle
+	dcgmLibHandle = nil
+	t.Cleanup(func() {
+		dcgmLibHandle = oldLibHandle
+	})
+
+	err := connectStandaloneV3("vsock://3:5555")
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dcgmConnect_v3 is not available in libdcgm.so.4")
+	require.Contains(t, err.Error(), "DCGM connection strings require DCGM 4.5.0 or newer")
+}


### PR DESCRIPTION
Adds dcgmConnect_v3 support for standalone DCGM connection strings in go-dcgm.
This change detects supported DCGM URI schemes:

  tcp://
  unix://
  vsock://

When dcgm.Init(dcgm.Standalone, <uri>) receives one supported URI argument, it routes through dcgmConnect_v3. Existing legacy standalone calls, such as host/port plus socket flag, continue to use the existing dcgmConnect_v2 path.


**Validation**
  - Added unit coverage for VSOCK, TCP, UNIX, uppercase schemes, legacy host/socket flag behavior, missing socket flag behavior, and unsupported scheme fallthrough.
  - Added runtime symbol guard for dcgmConnect_v3 to return a clear error if the deployed libdcgm.so.4 is too old.
  - Verified locally:
      - go test ./pkg/dcgm -count=1

  **Notes**
  - Requires runtime DCGM library version that exports dcgmConnect_v3.
  - This MR preserves existing dcgmConnect_v2 behavior for legacy standalone connection arguments.