### PR TITLE
feat(cpu): add CPUHierarchy_v2 binding with per-CPU serial

### DIFF
--- a/pkg/dcgm/cpu.go
+++ b/pkg/dcgm/cpu.go
@@ -50,7 +50,8 @@ type CPUHierarchy_v1 struct {
 	CPUs [MAX_NUM_CPUS]CPUHierarchyCPU_v1
 }
 
-// GetCPUHierarchy retrieves the CPU hierarchy information from DCGM
+// GetCPUHierarchy retrieves version 1 CPU hierarchy information from DCGM.
+// Use GetCPUHierarchy_v2 when CPU serials are needed.
 func GetCPUHierarchy() (hierarchy CPUHierarchy_v1, err error) {
 	var c_hierarchy C.dcgmCpuHierarchy_v1
 	c_hierarchy.version = C.dcgmCpuHierarchy_version1
@@ -58,14 +59,15 @@ func GetCPUHierarchy() (hierarchy CPUHierarchy_v1, err error) {
 	result := C.dcgmGetCpuHierarchy(handle.handle, ptr_hierarchy)
 
 	if err = errorString(result); err != nil {
-		return toCpuHierarchy(c_hierarchy), cpuHierarchyError("error retrieving DCGM CPU hierarchy", result)
+		dcgmErr := &Error{msg: err.Error(), Code: result}
+		return toCpuHierarchy(c_hierarchy), cpuHierarchyError("error retrieving DCGM CPU hierarchy", dcgmErr)
 	}
 
 	return toCpuHierarchy(c_hierarchy), nil
 }
 
-func cpuHierarchyError(operation string, result C.dcgmReturn_t) error {
-	return fmt.Errorf("%s: %w", operation, &Error{msg: C.GoString(C.errorString(result)), Code: result})
+func cpuHierarchyError(operation string, dcgmErr *Error) error {
+	return fmt.Errorf("%s: %w", operation, dcgmErr)
 }
 
 func toCpuHierarchy(c_hierarchy C.dcgmCpuHierarchy_v1) CPUHierarchy_v1 {
@@ -116,7 +118,8 @@ func GetCPUHierarchy_v2() (hierarchy CPUHierarchy_v2, err error) {
 	result := C.dcgmGetCpuHierarchy_v2(handle.handle, ptrHierarchy)
 
 	if err = errorString(result); err != nil {
-		return toCpuHierarchy_v2(cHierarchy), cpuHierarchyError("error retrieving DCGM CPU hierarchy v2", result)
+		dcgmErr := &Error{msg: err.Error(), Code: result}
+		return toCpuHierarchy_v2(cHierarchy), cpuHierarchyError("error retrieving DCGM CPU hierarchy v2", dcgmErr)
 	}
 
 	return toCpuHierarchy_v2(cHierarchy), nil

--- a/pkg/dcgm/cpu.go
+++ b/pkg/dcgm/cpu.go
@@ -83,3 +83,57 @@ func toCpuHierarchy(c_hierarchy C.dcgmCpuHierarchy_v1) CPUHierarchy_v1 {
 
 	return hierarchy
 }
+
+// CPUHierarchyCPU_v2 represents information about a single CPU, its owned cores, and its serial.
+type CPUHierarchyCPU_v2 struct {
+	// CPUID is the unique identifier for this CPU
+	CPUID uint
+	// OwnedCores is a bitmask array representing the cores owned by this CPU
+	OwnedCores []uint64
+	// Serial is the CPU serial number. It may be empty when unavailable.
+	Serial string
+}
+
+// CPUHierarchy_v2 represents version 2 of the CPU hierarchy information.
+type CPUHierarchy_v2 struct {
+	// Version is the version number of the hierarchy structure
+	Version uint
+	// NumCPUs is the number of CPUs in the system
+	NumCPUs uint
+	// CPUs contains information about each CPU in the system
+	CPUs [MAX_NUM_CPUS]CPUHierarchyCPU_v2
+}
+
+// GetCPUHierarchy_v2 retrieves version 2 CPU hierarchy information from DCGM.
+func GetCPUHierarchy_v2() (hierarchy CPUHierarchy_v2, err error) {
+	var cHierarchy C.dcgmCpuHierarchy_v2
+	cHierarchy.version = C.dcgmCpuHierarchy_version2
+	ptrHierarchy := (*C.dcgmCpuHierarchy_v2)(unsafe.Pointer(&cHierarchy))
+	result := C.dcgmGetCpuHierarchy_v2(handle.handle, ptrHierarchy)
+
+	if err = errorString(result); err != nil {
+		return toCpuHierarchy_v2(cHierarchy), fmt.Errorf("error retrieving DCGM CPU hierarchy v2: %s", err)
+	}
+
+	return toCpuHierarchy_v2(cHierarchy), nil
+}
+
+func toCpuHierarchy_v2(cHierarchy C.dcgmCpuHierarchy_v2) CPUHierarchy_v2 {
+	var hierarchy CPUHierarchy_v2
+	hierarchy.Version = uint(cHierarchy.version)
+	hierarchy.NumCPUs = uint(cHierarchy.numCpus)
+	for i := uint(0); i < hierarchy.NumCPUs; i++ {
+		bits := make([]uint64, MAX_CPU_CORE_BITMASK_COUNT)
+		for j := uint(0); j < MAX_CPU_CORE_BITMASK_COUNT; j++ {
+			bits[j] = uint64(cHierarchy.cpus[i].ownedCores.bitmask[j])
+		}
+
+		hierarchy.CPUs[i] = CPUHierarchyCPU_v2{
+			CPUID:      uint(cHierarchy.cpus[i].cpuId),
+			OwnedCores: bits,
+			Serial:     *stringPtr(&cHierarchy.cpus[i].serial[0]),
+		}
+	}
+
+	return hierarchy
+}

--- a/pkg/dcgm/cpu.go
+++ b/pkg/dcgm/cpu.go
@@ -65,11 +65,7 @@ func GetCPUHierarchy() (hierarchy CPUHierarchy_v1, err error) {
 }
 
 func cpuHierarchyError(operation string, result C.dcgmReturn_t) error {
-	return wrapCPUHierarchyError(operation, result, C.GoString(C.errorString(result)))
-}
-
-func wrapCPUHierarchyError(operation string, result C.dcgmReturn_t, status string) error {
-	return fmt.Errorf("%s: %w", operation, &Error{msg: status, Code: result})
+	return fmt.Errorf("%s: %w", operation, &Error{msg: C.GoString(C.errorString(result)), Code: result})
 }
 
 func toCpuHierarchy(c_hierarchy C.dcgmCpuHierarchy_v1) CPUHierarchy_v1 {

--- a/pkg/dcgm/cpu.go
+++ b/pkg/dcgm/cpu.go
@@ -58,10 +58,18 @@ func GetCPUHierarchy() (hierarchy CPUHierarchy_v1, err error) {
 	result := C.dcgmGetCpuHierarchy(handle.handle, ptr_hierarchy)
 
 	if err = errorString(result); err != nil {
-		return toCpuHierarchy(c_hierarchy), fmt.Errorf("error retrieving DCGM CPU hierarchy: %s", err)
+		return toCpuHierarchy(c_hierarchy), cpuHierarchyError("error retrieving DCGM CPU hierarchy", result)
 	}
 
 	return toCpuHierarchy(c_hierarchy), nil
+}
+
+func cpuHierarchyError(operation string, result C.dcgmReturn_t) error {
+	return wrapCPUHierarchyError(operation, result, C.GoString(C.errorString(result)))
+}
+
+func wrapCPUHierarchyError(operation string, result C.dcgmReturn_t, status string) error {
+	return fmt.Errorf("%s: %w", operation, &Error{msg: status, Code: result})
 }
 
 func toCpuHierarchy(c_hierarchy C.dcgmCpuHierarchy_v1) CPUHierarchy_v1 {
@@ -112,7 +120,7 @@ func GetCPUHierarchy_v2() (hierarchy CPUHierarchy_v2, err error) {
 	result := C.dcgmGetCpuHierarchy_v2(handle.handle, ptrHierarchy)
 
 	if err = errorString(result); err != nil {
-		return toCpuHierarchy_v2(cHierarchy), fmt.Errorf("error retrieving DCGM CPU hierarchy v2: %s", err)
+		return toCpuHierarchy_v2(cHierarchy), cpuHierarchyError("error retrieving DCGM CPU hierarchy v2", result)
 	}
 
 	return toCpuHierarchy_v2(cHierarchy), nil

--- a/pkg/dcgm/cpu_test.go
+++ b/pkg/dcgm/cpu_test.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dcgm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCPUHierarchyV2IncludesSerial(t *testing.T) {
+	lastBitmaskIndex := int(MAX_CPU_CORE_BITMASK_COUNT - 1)
+	hierarchy := createTestCPUHierarchyV2([]testCPUHierarchyV2CPU{
+		{
+			cpuID:  7,
+			serial: "GRACE-SERIAL-0007",
+			ownedCoreBitmasks: map[int]uint64{
+				0:                0b101,
+				1:                0b1000,
+				lastBitmaskIndex: 0b10,
+			},
+		},
+		{
+			cpuID:  8,
+			serial: "",
+			ownedCoreBitmasks: map[int]uint64{
+				0: 0b10000,
+			},
+		},
+	})
+
+	assert.Equal(t, uint(testCPUHierarchyVersion2), hierarchy.Version)
+	assert.Equal(t, uint(2), hierarchy.NumCPUs)
+	assert.Equal(t, uint(7), hierarchy.CPUs[0].CPUID)
+	assert.Len(t, hierarchy.CPUs[0].OwnedCores, int(MAX_CPU_CORE_BITMASK_COUNT))
+	assert.Equal(t, uint64(0b101), hierarchy.CPUs[0].OwnedCores[0])
+	assert.Equal(t, uint64(0b1000), hierarchy.CPUs[0].OwnedCores[1])
+	assert.Equal(t, uint64(0b10), hierarchy.CPUs[0].OwnedCores[lastBitmaskIndex])
+	assert.Equal(t, "GRACE-SERIAL-0007", hierarchy.CPUs[0].Serial)
+
+	assert.Equal(t, uint(8), hierarchy.CPUs[1].CPUID)
+	assert.Len(t, hierarchy.CPUs[1].OwnedCores, int(MAX_CPU_CORE_BITMASK_COUNT))
+	assert.Equal(t, uint64(0b10000), hierarchy.CPUs[1].OwnedCores[0])
+	assert.Empty(t, hierarchy.CPUs[1].Serial)
+}
+
+func TestCPUHierarchyV2HandlesEmptyHierarchy(t *testing.T) {
+	hierarchy := createTestCPUHierarchyV2(nil)
+
+	assert.Equal(t, uint(testCPUHierarchyVersion2), hierarchy.Version)
+	assert.Equal(t, uint(0), hierarchy.NumCPUs)
+}

--- a/pkg/dcgm/cpu_test.go
+++ b/pkg/dcgm/cpu_test.go
@@ -17,7 +17,6 @@
 package dcgm
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,32 +71,28 @@ func TestCPUHierarchyErrorWrapsDCGMError(t *testing.T) {
 		name      string
 		operation string
 		result    testDCGMReturn
-		status    string
 	}{
 		{
 			name:      "v1 hierarchy error",
 			operation: "error retrieving DCGM CPU hierarchy",
 			result:    testDCGMStatusVersionMismatch,
-			status:    "API version mismatch",
 		},
 		{
 			name:      "v2 hierarchy error",
 			operation: "error retrieving DCGM CPU hierarchy v2",
 			result:    testDCGMStatusFunctionNotFound,
-			status:    "The requested function was not found",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := wrapCPUHierarchyError(tt.operation, tt.result, tt.status)
+			err := cpuHierarchyError(tt.operation, tt.result)
 
 			require.Error(t, err)
 			assert.ErrorContains(t, err, tt.operation)
-			assert.ErrorContains(t, err, tt.status)
 
 			var dcgmErr *Error
-			require.True(t, errors.As(err, &dcgmErr))
+			require.ErrorAs(t, err, &dcgmErr)
 			assert.Equal(t, tt.result, dcgmErr.Code)
 		})
 	}

--- a/pkg/dcgm/cpu_test.go
+++ b/pkg/dcgm/cpu_test.go
@@ -17,9 +17,11 @@
 package dcgm
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCPUHierarchyV2IncludesSerial(t *testing.T) {
@@ -63,4 +65,40 @@ func TestCPUHierarchyV2HandlesEmptyHierarchy(t *testing.T) {
 
 	assert.Equal(t, uint(testCPUHierarchyVersion2), hierarchy.Version)
 	assert.Equal(t, uint(0), hierarchy.NumCPUs)
+}
+
+func TestCPUHierarchyErrorWrapsDCGMError(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation string
+		result    testDCGMReturn
+		status    string
+	}{
+		{
+			name:      "v1 hierarchy error",
+			operation: "error retrieving DCGM CPU hierarchy",
+			result:    testDCGMStatusVersionMismatch,
+			status:    "API version mismatch",
+		},
+		{
+			name:      "v2 hierarchy error",
+			operation: "error retrieving DCGM CPU hierarchy v2",
+			result:    testDCGMStatusFunctionNotFound,
+			status:    "The requested function was not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := wrapCPUHierarchyError(tt.operation, tt.result, tt.status)
+
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.operation)
+			assert.ErrorContains(t, err, tt.status)
+
+			var dcgmErr *Error
+			require.True(t, errors.As(err, &dcgmErr))
+			assert.Equal(t, tt.result, dcgmErr.Code)
+		})
+	}
 }

--- a/pkg/dcgm/cpu_test.go
+++ b/pkg/dcgm/cpu_test.go
@@ -86,7 +86,7 @@ func TestCPUHierarchyErrorWrapsDCGMError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := cpuHierarchyError(tt.operation, tt.result)
+			err := cpuHierarchyError(tt.operation, &Error{msg: "dcgm error", Code: tt.result})
 
 			require.Error(t, err)
 			assert.ErrorContains(t, err, tt.operation)

--- a/pkg/dcgm/cpu_test_helpers.go
+++ b/pkg/dcgm/cpu_test_helpers.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dcgm
+
+/*
+#include <stdlib.h>
+#include <string.h>
+#include "dcgm_agent.h"
+#include "dcgm_structs.h"
+*/
+import "C"
+
+import "unsafe"
+
+const testCPUHierarchyVersion2 = C.dcgmCpuHierarchy_version2
+
+type testCPUHierarchyV2CPU struct {
+	cpuID             uint
+	ownedCoreBitmasks map[int]uint64
+	serial            string
+}
+
+// createTestCPUHierarchyV2 creates and converts a dcgmCpuHierarchy_v2 for testing.
+func createTestCPUHierarchyV2(cpus []testCPUHierarchyV2CPU) CPUHierarchy_v2 {
+	var hierarchy C.dcgmCpuHierarchy_v2
+	hierarchy.version = C.dcgmCpuHierarchy_version2
+	hierarchy.numCpus = C.uint(len(cpus))
+
+	for i, cpu := range cpus {
+		hierarchy.cpus[i].cpuId = C.uint(cpu.cpuID)
+
+		for bitmaskIndex, bitmask := range cpu.ownedCoreBitmasks {
+			hierarchy.cpus[i].ownedCores.bitmask[bitmaskIndex] = C.uint64_t(bitmask)
+		}
+
+		cSerial := C.CString(cpu.serial)
+		C.strncpy(&hierarchy.cpus[i].serial[0], cSerial, C.DCGM_MAX_STR_LENGTH-1)
+		C.free(unsafe.Pointer(cSerial))
+	}
+
+	return toCpuHierarchy_v2(hierarchy)
+}

--- a/pkg/dcgm/cpu_test_helpers.go
+++ b/pkg/dcgm/cpu_test_helpers.go
@@ -26,7 +26,13 @@ import "C"
 
 import "unsafe"
 
-const testCPUHierarchyVersion2 = C.dcgmCpuHierarchy_version2
+const (
+	testCPUHierarchyVersion2       = C.dcgmCpuHierarchy_version2
+	testDCGMStatusVersionMismatch  = C.DCGM_ST_VER_MISMATCH
+	testDCGMStatusFunctionNotFound = C.DCGM_ST_FUNCTION_NOT_FOUND
+)
+
+type testDCGMReturn = C.dcgmReturn_t
 
 type testCPUHierarchyV2CPU struct {
 	cpuID             uint


### PR DESCRIPTION
Adds Go bindings for `dcgmGetCpuHierarchy_v2()` so callers can access the Grace CPU serial returned by DCGM.

  ### Changes

  - Add `CPUHierarchy_v2` / `CPUHierarchyCPU_v2` support.
  - Convert the v2 C hierarchy into Go structs, including `Serial`.
  - Keep the existing v1 CPU hierarchy API unchanged.
  - Add converter tests that exercise real C-struct conversion, including:
    - populated serial
    - empty hierarchy / `NumCPUs == 0`
    - CPU/core conversion coverage

  ### Validation

  - `go test ./pkg/dcgm`